### PR TITLE
Make STA() to return mt940 data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,6 @@
 {
   "name": "andrew-svirin/ebics-client-php",
-<<<<<<< HEAD
   "version": "1.0.2",
-=======
->>>>>>> 7d8f2b68cd2ad93317f66771a907ba8b97dac02a
   "type": "library",
   "description": "PHP library to communicate with bank through EBICS protocol.",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "andrew-svirin/ebics-client-php",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "library",
   "description": "PHP library to communicate with bank through EBICS protocol.",
   "keywords": [
@@ -22,7 +22,6 @@
     "php": "^7.2",
     "ext-dom": "*",
     "ext-openssl": "*",
-    "andrew-svirin/mt942-php": "1.0.0",
     "comodojo/httprequest": "~1.0",
     "phpseclib/phpseclib": "~2.0",
     "ext-zlib": "*",

--- a/src/Handlers/ResponseHandler.php
+++ b/src/Handlers/ResponseHandler.php
@@ -83,7 +83,7 @@ class ResponseHandler
       $xpath = $this->prepareH004XPath($xml);
       $orderData = $xpath->query('//H004:body/H004:DataTransfer/H004:OrderData');
       $transactionKey = $xpath->query('//H004:body/H004:DataTransfer/H004:DataEncryptionInfo/H004:TransactionKey');
-      if (!$orderData || !$transactionKey)
+      if (!$orderData || $orderData->length == 0 || !$transactionKey || $transactionKey->length == 0)
       {
          throw new EbicsException('EBICS response empty result.');
       }

--- a/src/Handlers/Traits/XPathTrait.php
+++ b/src/Handlers/Traits/XPathTrait.php
@@ -23,6 +23,7 @@ trait XPathTrait
    {
       $xpath = new DomXpath($xml);
       $xpath->registerNamespace('H004', 'urn:org:ebics:H004');
+      $xpath->registerNamespace('ds', 'http://www.w3.org/2000/09/xmldsig#');
       return $xpath;
    }
 

--- a/src/Models/OrderDataDecrypted.php
+++ b/src/Models/OrderDataDecrypted.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AndrewSvirin\Ebics\Models;
+
+/**
+ * Class OrderDataDecrypted represents OrderData Response model.
+ *
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ */
+class OrderDataDecrypted extends OrderDataEncrypted
+{
+}

--- a/src/Models/Response.php
+++ b/src/Models/Response.php
@@ -14,7 +14,7 @@ class Response extends DOMDocument
    /**
     * @var Transaction[]
     */
-   private $transactions;
+   private $transactions = [];
 
    /**
     * @param Transaction $transaction

--- a/src/Models/Response.php
+++ b/src/Models/Response.php
@@ -15,6 +15,10 @@ class Response extends DOMDocument
     * @var Transaction[]
     */
    private $transactions = [];
+   /**
+    * @var OrderDataDecrypted
+    */
+   private $decryptedOrderData;
 
    /**
     * @param Transaction $transaction
@@ -31,5 +35,25 @@ class Response extends DOMDocument
    {
       return $this->transactions;
    }
+
+   /**
+    * @return OrderDataDecrypted
+    */
+   public function getDecryptedOrderData(): ?OrderDataDecrypted
+   {
+      return $this->decryptedOrderData;
+   }
+
+   /**
+    * @param OrderDataDecrypted $decryptedOrderData
+    * @return self
+    */
+   public function setDecryptedOrderData(OrderDataDecrypted $decryptedOrderData): self
+   {
+      $this->decryptedOrderData = $decryptedOrderData;
+
+      return $this;
+   }
+
 
 }

--- a/src/Services/CryptService.php
+++ b/src/Services/CryptService.php
@@ -3,10 +3,9 @@
 namespace AndrewSvirin\Ebics\Services;
 
 use AndrewSvirin\Ebics\Exceptions\EbicsException;
-use AndrewSvirin\Ebics\Factories\OrderDataFactory;
 use AndrewSvirin\Ebics\Models\Certificate;
 use AndrewSvirin\Ebics\Models\KeyRing;
-use AndrewSvirin\Ebics\Models\OrderData;
+use AndrewSvirin\Ebics\Models\OrderDataDecrypted;
 use AndrewSvirin\Ebics\Models\OrderDataEncrypted;
 use phpseclib\Crypt\AES;
 use phpseclib\Crypt\Random;
@@ -36,9 +35,9 @@ class CryptService
     * Decrypt encrypted OrDerData.
     * @param KeyRing $keyRing
     * @param OrderDataEncrypted $orderData
-    * @return OrderData
+    * @return OrderDataDecrypted
     */
-   public static function decryptOrderData(KeyRing $keyRing, OrderDataEncrypted $orderData): OrderData
+   public static function decryptOrderData(KeyRing $keyRing, OrderDataEncrypted $orderData): OrderDataDecrypted
    {
       $rsa = new RSA();
       $rsa->setPassword($keyRing->getPassword());
@@ -52,9 +51,7 @@ class CryptService
       // Force openssl_options.
       $aes->openssl_options = OPENSSL_ZERO_PADDING;
       $decrypted = $aes->decrypt($orderData->getOrderData());
-      $content = gzuncompress($decrypted);
-      $orderData = OrderDataFactory::buildOrderDataFromContent($content);
-      return $orderData;
+      return new OrderDataDecrypted(gzuncompress($decrypted), $orderData->getTransactionKey());
    }
 
    /**


### PR DESCRIPTION
Hello,
thank you for that great library!

I wrote a EasyEbics library on top of it and had a few problems while writing it.
I needed to register a "ds" namespace with the value that I got in the response of a german bank. Don't know if this is correct for everyone, but I needed it to get it working.

The STA response contains mt940 data, but the CryptService could only decrypt and build a OrderData object at once. I moved the call to OrderDataFactory::buildOrderDataFromContent from CryptService::decryptOrderData to the caller and added the decrypted data to the Response class so that the result of the STA can be accessed.

Additionaly, I could not find any reference from the code to your mt942-php library and thus I removed this dependency. I hope this is okay.