### PR TITLE
Addtransfer receipt methods to interface

### DIFF
--- a/src/Contracts/EbicsClientInterface.php
+++ b/src/Contracts/EbicsClientInterface.php
@@ -88,4 +88,9 @@ interface EbicsClientInterface
      * @param DateTime|null $endDateTime   the end date of requested transactions
      */
     public function STA(DateTime $dateTime = null, DateTime $startDateTime = null, DateTime $endDateTime = null): Response;
+
+    /**
+     * Mark transactions as received.
+     */
+    public function transferReceipt(Response $response, bool $acknowledged = true): Response;
 }

--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -351,7 +351,7 @@ final class EbicsClient implements EbicsClientInterface
         return $response;
     }
 
-    public function transferReceipt(Response $response, bool $acknowledged = true)
+    public function transferReceipt(Response $response, bool $acknowledged = true) : Response
     {
         $lastTransaction = $response->getLastTransaction();
         if (null === $lastTransaction) {


### PR DESCRIPTION
Hello,

`AndrewSvirin\Ebics\EbicsClient` is marked as final so it cant be mock.
I have added `transferReceipt` method to `AndrewSvirin\Ebics\Contracts\EbicsClientInterface` so it can be mocked.

Thanks