### PR TITLE
Added support for Camt.053 bank statement format

### DIFF
--- a/src/Contracts/EbicsClientInterface.php
+++ b/src/Contracts/EbicsClientInterface.php
@@ -90,6 +90,14 @@ interface EbicsClientInterface
     public function STA(DateTime $dateTime = null, DateTime $startDateTime = null, DateTime $endDateTime = null): Response;
 
     /**
+     * Retrieve the bank account statement in Camt.053 format.
+     *
+     * @param DateTime|null $startDateTime the start date of requested transactions
+     * @param DateTime|null $endDateTime   the end date of requested transactions
+     */
+    public function C53(DateTime $dateTime = null, DateTime $startDateTime = null, DateTime $endDateTime = null): Response;
+
+    /**
      * Mark transactions as received.
      */
     public function transferReceipt(Response $response, bool $acknowledged = true): Response;

--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -449,6 +449,31 @@ final class EbicsClient implements EbicsClientInterface
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * @throws ClientExceptionInterface
+     * @throws RedirectionExceptionInterface
+     * @throws ServerExceptionInterface
+     * @throws TransportExceptionInterface
+     * @throws Exceptions\EbicsException
+     */
+    public function C53(DateTime $dateTime = null, DateTime $startDateTime = null, DateTime $endDateTime = null): Response
+    {
+        if (null === $dateTime) {
+            $dateTime = new DateTime();
+        }
+        $request = $this->requestFactory->buildC53($dateTime, $startDateTime, $endDateTime);
+        $hostResponse = $this->post($request);
+        $hostResponseContent = $hostResponse->getContent();
+        $response = new Response();
+        $response->loadXML($hostResponseContent);
+
+        $this->checkH004ReturnCode($request, $response);
+
+        return $response;
+    }
+
+    /**
      * @throws EbicsResponseExceptionInterface
      */
     private function checkH004ReturnCode(Request $request, Response $response): void

--- a/src/Handlers/HeaderHandler.php
+++ b/src/Handlers/HeaderHandler.php
@@ -25,6 +25,7 @@ class HeaderHandler
     const ORDER_TYPE_HPB = 'HPB';
     const ORDER_TYPE_VMK = 'VMK';
     const ORDER_TYPE_STA = 'STA';
+    const ORDER_TYPE_C53 = 'C53';
     const ORDER_TYPE_HAA = 'HAA';
     const ORDER_TYPE_HPD = 'HPD';
     const ORDER_TYPE_HKD = 'HKD';
@@ -172,17 +173,36 @@ class HeaderHandler
     public function handleSTA(DOMDocument $xml, DOMElement $xmlRequest, DateTime $dateTime, DateTime $startDateTime = null, DateTime $endDateTime = null) : void
     {
         $this->handle(
-         $xml,
-         $xmlRequest,
-         $this->handleNonce($dateTime),
-         $this->handleBank(),
-         $this->handleOrderDetails(
-            self::ORDER_TYPE_STA,
-            self::ORDER_ATTRIBUTE_DZHNN,
-            $this->handleStandardOrderParams($startDateTime, $endDateTime)
-         ),
-         $this->handleMutable($this->handleTransactionPhase(Transaction::PHASE_INITIALIZATION))
-      );
+            $xml,
+            $xmlRequest,
+            $this->handleNonce($dateTime),
+            $this->handleBank(),
+            $this->handleOrderDetails(
+                self::ORDER_TYPE_STA,
+                self::ORDER_ATTRIBUTE_DZHNN,
+                $this->handleStandardOrderParams($startDateTime, $endDateTime)
+            ),
+            $this->handleMutable($this->handleTransactionPhase(Transaction::PHASE_INITIALIZATION))
+        );
+    }
+
+    /**
+     * Add header for C53 Request XML.
+     */
+    public function handleC53(DOMDocument $xml, DOMElement $xmlRequest, DateTime $dateTime, DateTime $startDateTime = null, DateTime $endDateTime = null) : void
+    {
+        $this->handle(
+            $xml,
+            $xmlRequest,
+            $this->handleNonce($dateTime),
+            $this->handleBank(),
+            $this->handleOrderDetails(
+                self::ORDER_TYPE_C53,
+                self::ORDER_ATTRIBUTE_DZHNN,
+                $this->handleStandardOrderParams($startDateTime, $endDateTime)
+            ),
+            $this->handleMutable($this->handleTransactionPhase(Transaction::PHASE_INITIALIZATION))
+        );
     }
 
     /**

--- a/src/Handlers/RequestHandler.php
+++ b/src/Handlers/RequestHandler.php
@@ -224,4 +224,18 @@ class RequestHandler
 
         return $request;
     }
+
+    /**
+     * @throws EbicsException
+     */
+    public function buildC53(DateTime $dateTime, DateTime $startDateTime = null, DateTime $endDateTime = null): Request
+    {
+        $request = new Request();
+        $xmlRequest = $this->ebicsRequestHandler->handleSecured($request);
+        $this->headerHandler->handleC53($request, $xmlRequest, $dateTime, $startDateTime, $endDateTime);
+        $this->authSignatureHandler->handle($request, $xmlRequest);
+        $this->bodyHandler->handleEmpty($request, $xmlRequest);
+
+        return $request;
+    }
 }


### PR DESCRIPTION
Hi, 

this feature adds support for the Camt.053 bank statement format. 

For more info about this format : 
https://www.sepaforcorporates.com/swift-for-corporates/a-practical-guide-to-the-bank-statement-camt-053-format/

Regards,