### PR TITLE
Fixed double POST call on FDL

### DIFF
--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -364,13 +364,6 @@ final class EbicsClient implements EbicsClientInterface
         }
 
         $request = $this->requestFactory->createFDL($dateTime, $fileInfo, $countryCode, $startDateTime, $endDateTime);
-        $response = $this->httpClient->post($this->bank->getUrl(), $request);
-
-        $this->checkH004ReturnCode($request, $response);
-
-        $transaction = $this->responseHandler->retrieveTransaction($response);
-        $response->addTransaction($transaction);
-
         switch ($format) {
             case 'plain':
                 $response = $this->retrievePlainOrderData($request);


### PR DESCRIPTION
Hi there,

I've finally managed the MESSAGE_REPLAY issue.
It was not due to the nonce generation as I thought first. In fact, in the client's FDL method, the `post` method was called twice.

If you want, I can make another PR to revert back the nonce generation algorithm.

Sorry for the extra work.