### PR TITLE
Implement Z54 command (camt.054)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,30 @@ try {
 | STA | Retrieve the bank account statement. |
 | C53 | Retrieve the bank account statement in Camt.053 format. |
 | Z53 | Another way to retrieve the bank account statement in Camt.053 format (i.e Switzerland financial services). |
+| Z54 | Retrieve a bank account statement in Camt.054 format (i.e available in Switzerland). |
 | CCT | Initiate the credit transfer per Single Euro Payments Area. |
 | CDD | Initiate a direct debit transaction. |
+
+#### Unzipping EBICS response.
+
+Some responses are zipped content which requires unzipping them first to use the XML content.
+In this example, we use PHP's ZipArchive which requires `ext-zip` extension to unzip a camt.054 response.
+
+```php
+$zip = new \ZipArchive();
+
+/* @var \AndrewSvirin\Ebics\EbicsClient $client */
+$z54 = $client->Z54();
+
+// ... write $z54 content into a file (zip)
+
+$inputPath = 'zip-file-path';
+$outputDir = 'your-output-directory';
+
+$zip->extractTo($outputDir, $inputPath);
+
+```
+
+You'll find one or many XML files in your output directory.
 
 ### 6. Make HKD request to see what order types allowed.

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ try {
 
 #### Unzipping EBICS response.
 
-Some responses are zipped content which requires unzipping them first to use the XML content.
+Some responses are sent as zipped content and therefore require unzipping them first to access the XML content.
 In this example, we use PHP's ZipArchive which requires `ext-zip` extension to unzip a camt.054 response.
 
 ```php

--- a/src/Contracts/EbicsClientInterface.php
+++ b/src/Contracts/EbicsClientInterface.php
@@ -193,6 +193,24 @@ interface EbicsClientInterface
     // @codingStandardsIgnoreEnd
 
     /**
+     * Retrieve a bank account statement in Camt.054 format (i.e available in Switzerland)
+     * Send self::transferReceipt() after transaction finished.
+     *
+     * @param DateTimeInterface|null $dateTime
+     * @param DateTimeInterface|null $startDateTime the start date of requested transactions
+     * @param DateTimeInterface|null $endDateTime the end date of requested transactions
+     *
+     * @return Response zipped camt.054 XML files.
+     */
+    // @codingStandardsIgnoreStart
+    public function Z54(
+        DateTimeInterface $dateTime = null,
+        DateTimeInterface $startDateTime = null,
+        DateTimeInterface $endDateTime = null
+    ): Response;
+    // @codingStandardsIgnoreEnd
+
+    /**
      * Using the CCT order type, the user can initiate the credit transfer per Single Euro Payments Area (SEPA)
      * specification set by the European Payment Council or Die Deutsche Kreditwirtschaft (DK (German)).
      *

--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -351,6 +351,26 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws Exceptions\EbicsException
      */
+    // @codingStandardsIgnoreStart
+    public function Z54(
+        DateTimeInterface $dateTime = null,
+        DateTimeInterface $startDateTime = null,
+        DateTimeInterface $endDateTime = null
+    ): Response {
+        // @codingStandardsIgnoreEnd
+        if (null === $dateTime) {
+            $dateTime = new DateTime();
+        }
+        $request = $this->requestFactory->createZ54($dateTime, $startDateTime, $endDateTime);
+        $response = $this->retrievePlainOrderData($request);
+
+        return $response;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exceptions\EbicsException
+     */
     public function FDL(
         $fileInfo,
         $format = 'plain',

--- a/tests/EbicsClientTest.php
+++ b/tests/EbicsClientTest.php
@@ -430,6 +430,37 @@ class EbicsClientTest extends AbstractEbicsTestCase
     /**
      * @dataProvider serversDataProvider
      *
+     * @group Z54
+     *
+     * @param int $credentialsId
+     * @param array $codes
+     * @param X509GeneratorInterface|null $x509Generator
+     *
+     * @covers
+     */
+    public function testZ54(int $credentialsId, array $codes, X509GeneratorInterface $x509Generator = null)
+    {
+        $client = $this->setupClient($credentialsId, $x509Generator, $codes['Z54']['fake']);
+
+        $this->assertExceptionCode($codes['Z54']['code']);
+        $z54 = $client->Z54(
+            new DateTime(),
+            (new DateTime())->modify('-30 day'),
+            (new DateTime())->modify('-1 day')
+        );
+
+        $responseHandler = new ResponseHandler();
+
+        $z54Receipt = $client->transferReceipt($z54);
+        $code = $responseHandler->retrieveH004ReturnCode($z54Receipt);
+        $reportText = $responseHandler->retrieveH004ReportText($z54Receipt);
+
+        $this->assertResponseDone($code, $reportText);
+    }
+
+    /**
+     * @dataProvider serversDataProvider
+     *
      * @group C53
      *
      * @param int $credentialsId
@@ -564,6 +595,7 @@ class EbicsClientTest extends AbstractEbicsTestCase
                     'VMK' => ['code' => '091005', 'fake' => false],
                     'STA' => ['code' => '091005', 'fake' => false],
                     'Z53' => ['code' => '090005', 'fake' => false],
+                    'Z54' => ['code' => '090005', 'fake' => false],
                     'C53' => ['code' => '091005', 'fake' => false],
                     'FDL' => [
                         'camt.xxx.cfonb120.stm' => ['code' => '091112', 'fake' => false],
@@ -588,6 +620,7 @@ class EbicsClientTest extends AbstractEbicsTestCase
                     'VMK' => ['code' => '061002', 'fake' => false],
                     'STA' => ['code' => '061002', 'fake' => false],
                     'Z53' => ['code' => '061002', 'fake' => false],
+                    'Z54' => ['code' => '061002', 'fake' => false],
                     'C53' => ['code' => '061002', 'fake' => false],
                     'FDL' => [
                         'camt.xxx.cfonb120.stm' => ['code' => '091010', 'fake' => false],
@@ -613,6 +646,7 @@ class EbicsClientTest extends AbstractEbicsTestCase
                     'VMK' => ['code' => '090003', 'fake' => false],
                     'STA' => ['code' => '090003', 'fake' => false],
                     'Z53' => ['code' => '090005', 'fake' => false],
+                    'Z54' => ['code' => '090005', 'fake' => false],
                     'C53' => ['code' => '090003', 'fake' => false],
                     'FDL' => [
                         'camt.xxx.cfonb120.stm' => ['code' => '091112', 'fake' => false],
@@ -637,6 +671,7 @@ class EbicsClientTest extends AbstractEbicsTestCase
                     'VMK' => ['code' => '090005', 'fake' => false],
                     'STA' => ['code' => '090005', 'fake' => false],
                     'Z53' => ['code' => '090005', 'fake' => false],
+                    'Z54' => ['code' => '090005', 'fake' => false],
                     'C53' => ['code' => '090003', 'fake' => false],
                     'FDL' => [
                         'camt.xxx.cfonb120.stm' => ['code' => '091112', 'fake' => false],


### PR DESCRIPTION
This PR extends the EBICS client with the Z54 command, used i.e. in Switzerland for ISO 20022 camt.054 transactions. SIX documented it in [this PDF](https://www.six-group.com/dam/download/banking-services/interbank-clearing/en/standardization/ebics/ebics.pdf) on page 9.

- [x] Extended tests for Z54
- [x] All tests in the green
- [x] Updated README

Since I didn't got that ZIP thing, I thought it's maybe useful to leave a hint in the README.