### PR TITLE
Fix example code of BankLetter generation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ $bankLetter = $ebicsBankLetter->prepareBankLetter(
     $client->getKeyRing()
 );
 
-$txt = $ebicsBankLetter->formatBankLetter($bankLetter, new \AndrewSvirin\Ebics\Services\BankLetterFormatterTxt());
+$txt = $ebicsBankLetter->formatBankLetter($bankLetter, new \AndrewSvirin\Ebics\Services\BankLetter\Formatter\TxtBankLetterFormatter());
 ```
 
 ### 3. Wait for the bank validation and activation access.


### PR DESCRIPTION
The example was not working since the class moved to another namespace.