### PR TITLE
Add method to generate user signatures prior to INI and HIA methods

### DIFF
--- a/src/Contracts/EbicsClientInterface.php
+++ b/src/Contracts/EbicsClientInterface.php
@@ -14,6 +14,11 @@ use DateTimeInterface;
 interface EbicsClientInterface
 {
     /**
+     * Create user signatures A, E and X
+     */
+    public function createUserSignatures(): void;
+
+    /**
      * Supported protocol version for the Bank.
      *
      * @return Response

--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -5,6 +5,7 @@ namespace AndrewSvirin\Ebics;
 use AndrewSvirin\Ebics\Contracts\EbicsClientInterface;
 use AndrewSvirin\Ebics\Contracts\HttpClientInterface;
 use AndrewSvirin\Ebics\Contracts\OrderDataInterface;
+use AndrewSvirin\Ebics\Contracts\SignatureInterface;
 use AndrewSvirin\Ebics\Contracts\X509GeneratorInterface;
 use AndrewSvirin\Ebics\Exceptions\EbicsException;
 use AndrewSvirin\Ebics\Factories\EbicsExceptionFactory;
@@ -16,6 +17,7 @@ use AndrewSvirin\Ebics\Models\Bank;
 use AndrewSvirin\Ebics\Models\Http\Request;
 use AndrewSvirin\Ebics\Models\Http\Response;
 use AndrewSvirin\Ebics\Models\KeyRing;
+use AndrewSvirin\Ebics\Models\Signature;
 use AndrewSvirin\Ebics\Models\User;
 use AndrewSvirin\Ebics\Services\CryptService;
 use AndrewSvirin\Ebics\Services\HttpClient;
@@ -108,6 +110,21 @@ final class EbicsClient implements EbicsClientInterface
     /**
      * @inheritDoc
      */
+    public function createUserSignatures(): void
+    {
+        $signatureA = $this->getUserSignature(Signature::TYPE_A, true);
+        $this->keyRing->setUserSignatureA($signatureA);
+
+        $signatureE = $this->getUserSignature(Signature::TYPE_E, true);
+        $this->keyRing->setUserSignatureE($signatureE);
+
+        $signatureX = $this->getUserSignature(Signature::TYPE_X, true);
+        $this->keyRing->setUserSignatureX($signatureX);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function HEV(): Response
     {
         $request = $this->requestFactory->createHEV();
@@ -123,16 +140,14 @@ final class EbicsClient implements EbicsClientInterface
      *
      * @throws EbicsException
      */
-    public function INI(DateTimeInterface $dateTime = null): Response
+    public function INI(DateTimeInterface $dateTime = null, bool $newSignature = false): Response
     {
         if (null === $dateTime) {
             $dateTime = new DateTime();
         }
-        $signatureA = $this->signatureFactory->createSignatureAFromKeys(
-            $this->cryptService->generateKeys($this->keyRing->getPassword()),
-            $this->keyRing->getPassword(),
-            $this->bank->isCertified() ? $this->x509Generator : null
-        );
+
+        $signatureA = $this->getUserSignature(Signature::TYPE_A, $newSignature);
+
         $request = $this->requestFactory->createINI($signatureA, $dateTime);
         $response = $this->httpClient->post($this->bank->getUrl(), $request);
 
@@ -146,21 +161,15 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws EbicsException
      */
-    public function HIA(DateTimeInterface $dateTime = null): Response
+    public function HIA(DateTimeInterface $dateTime = null, bool $newSignature = false): Response
     {
         if (null === $dateTime) {
             $dateTime = new DateTime();
         }
-        $signatureE = $this->signatureFactory->createSignatureEFromKeys(
-            $this->cryptService->generateKeys($this->keyRing->getPassword()),
-            $this->keyRing->getPassword(),
-            $this->bank->isCertified() ? $this->x509Generator : null
-        );
-        $signatureX = $this->signatureFactory->createSignatureXFromKeys(
-            $this->cryptService->generateKeys($this->keyRing->getPassword()),
-            $this->keyRing->getPassword(),
-            $this->bank->isCertified() ? $this->x509Generator : null
-        );
+
+        $signatureE = $this->getUserSignature(Signature::TYPE_E, $newSignature);
+        $signatureX = $this->getUserSignature(Signature::TYPE_X, $newSignature);
+
         $request = $this->requestFactory->createHIA($signatureE, $signatureX, $dateTime);
         $response = $this->httpClient->post($this->bank->getUrl(), $request);
 
@@ -664,5 +673,41 @@ final class EbicsClient implements EbicsClientInterface
     public function setHttpClient(HttpClientInterface $httpClient): void
     {
         $this->httpClient = $httpClient;
+    }
+
+    /**
+     * @param string $type
+     * @param bool $newSignature
+     *
+     * @return SignatureInterface
+     */
+    private function getUserSignature(string $type, bool $newSignature = false): SignatureInterface
+    {
+        switch ($type) {
+            case Signature::TYPE_A:
+                $getterMethod = "getUserSignatureA";
+                $factoryMethod = "createSignatureAFromKeys";
+                break;
+
+            case Signature::TYPE_E:
+                $getterMethod = "getUserSignatureE";
+                $factoryMethod = "createSignatureEFromKeys";
+                break;
+            case Signature::TYPE_X:
+                $getterMethod = "getUserSignatureX";
+                $factoryMethod = "createSignatureXFromKeys";
+                break;
+        }
+
+        $signature = $this->keyRing->$getterMethod();
+        if (!$signature || $newSignature) {
+            $signature = $this->signatureFactory->$factoryMethod(
+                $this->cryptService->generateKeys($this->keyRing->getPassword()),
+                $this->keyRing->getPassword(),
+                $this->bank->isCertified() ? $this->x509Generator : null
+            );
+        }
+
+        return $signature;
     }
 }


### PR DESCRIPTION
In some cases (At least for Caisse d'Epargne bank), users signatures must be validated by the bank before ordering INI and HIA requests.
So I added a method to generate the signatures outside the INI and HIA methods.
In those methods, I also check the existence of the signatures from the keyring before creating new one in order to keep the signatures validated by the bank