### PR TITLE
HttpClient security level update

### DIFF
--- a/src/Services/HttpClient.php
+++ b/src/Services/HttpClient.php
@@ -35,6 +35,7 @@ class HttpClient implements HttpClientInterface
         ]);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_setopt($ch, CURLOPT_SSL_CIPHER_LIST, 'DEFAULT@SECLEVEL=1');
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
SSL connection security level is downgraded to security level 1 in order to avoid empty responses when bank ssl configuration is too weak.
See https://stackoverflow.com/questions/58342699/php-curl-curl-error-35-error1414d172ssl-routinestls12-check-peer-sigalgwr for more informations