### PR TITLE
Add a BTFContext class for EBICS 3.0 BTF requests (BTD/BTU) 

### DIFF
--- a/src/Builders/Request/OrderDetailsBuilder.php
+++ b/src/Builders/Request/OrderDetailsBuilder.php
@@ -2,6 +2,7 @@
 
 namespace AndrewSvirin\Ebics\Builders\Request;
 
+use AndrewSvirin\Ebics\Contexts\BTFContext;
 use DateTimeInterface;
 use DOMDocument;
 use DOMElement;
@@ -122,9 +123,7 @@ class OrderDetailsBuilder
     }
 
     public function addBTDOrderParams(
-        string $serviceName,
-        string $scope,
-        string $msgName,
+        BTFContext $btfContext,
         ?DateTimeInterface $startDateTime = null,
         ?DateTimeInterface $endDateTime = null
     ): OrderDetailsBuilder {
@@ -136,20 +135,53 @@ class OrderDetailsBuilder
         $xmlService = $this->dom->createElement('Service');
         $xmlBTDOrderParams->appendChild($xmlService);
 
-        // Add ServiceName to Service.
-        $xmlServiceName = $this->dom->createElement('ServiceName');
-        $xmlServiceName->nodeValue = $serviceName;
-        $xmlService->appendChild($xmlServiceName);
+        // Add optionnal ServiceName to Service.
+        if (null !== $btfContext->getServiceName()) {
+            $xmlServiceName = $this->dom->createElement('ServiceName');
+            $xmlServiceName->nodeValue = $btfContext->getServiceName();
+            $xmlService->appendChild($xmlServiceName);
+        }
 
-        // Add Scope to Service.
-        $xmlScope = $this->dom->createElement('Scope');
-        $xmlScope->nodeValue = $scope;
-        $xmlService->appendChild($xmlScope);
+        // Add optionnal ServiceOption to Service.
+        if (null !== $btfContext->getServiceOption()) {
+            $xmlServiceOption = $this->dom->createElement('ServiceOption');
+            $xmlServiceOption->nodeValue = $btfContext->getServiceOption();
+            $xmlService->appendChild($xmlServiceOption);
+        }
+
+        // Add optionnal ContainerFlag to Service.
+        if (null !== $btfContext->getContainerFlag()) {
+            $xmlContainerFlag = $this->dom->createElement('ContainerFlag');
+            $xmlContainerFlag->nodeValue = $btfContext->getContainerFlag();
+            $xmlService->appendChild($xmlContainerFlag);
+        }
+
+        // Add optionnal Scope to Service.
+        if (null !== $btfContext->getScope()) {
+            $xmlScope = $this->dom->createElement('Scope');
+            $xmlScope->nodeValue = $btfContext->getScope();
+            $xmlService->appendChild($xmlScope);
+        }
 
         // Add MsgName to Service.
         $xmlMsgName = $this->dom->createElement('MsgName');
-        $xmlMsgName->nodeValue = $msgName;
+        $xmlMsgName->nodeValue = $btfContext->getMsgName();
         $xmlService->appendChild($xmlMsgName);
+
+        // Add optionnal MsgName version attribute
+        if (null !== $btfContext->getMsgNameVersion()) {
+            $xmlMsgName->setAttribute('version', $btfContext->getMsgNameVersion());
+        }
+
+        // Add optionnal MsgName variant attribute
+        if (null !== $btfContext->getMsgNameVariant()) {
+            $xmlMsgName->setAttribute('variant', $btfContext->getMsgNameVariant());
+        }
+
+        // Add optionnal MsgName format attribute
+        if (null !== $btfContext->getMsgNameFormat()) {
+            $xmlMsgName->setAttribute('format', $btfContext->getMsgNameFormat());
+        }
 
         if (null !== $startDateTime && null !== $endDateTime) {
             // Add DateRange to BTDOrderParams.

--- a/src/Builders/Request/OrderDetailsBuilder.php
+++ b/src/Builders/Request/OrderDetailsBuilder.php
@@ -135,12 +135,10 @@ class OrderDetailsBuilder
         $xmlService = $this->dom->createElement('Service');
         $xmlBTDOrderParams->appendChild($xmlService);
 
-        // Add optionnal ServiceName to Service.
-        if (null !== $btfContext->getServiceName()) {
-            $xmlServiceName = $this->dom->createElement('ServiceName');
-            $xmlServiceName->nodeValue = $btfContext->getServiceName();
-            $xmlService->appendChild($xmlServiceName);
-        }
+        // Add ServiceName to Service.
+        $xmlServiceName = $this->dom->createElement('ServiceName');
+        $xmlServiceName->nodeValue = $btfContext->getServiceName();
+        $xmlService->appendChild($xmlServiceName);
 
         // Add optionnal ServiceOption to Service.
         if (null !== $btfContext->getServiceOption()) {

--- a/src/Contexts/BTFContext.php
+++ b/src/Contexts/BTFContext.php
@@ -57,7 +57,7 @@ class BTFContext
         return $this;
     }
 
-    public function getServiceName(): ?string
+    public function getServiceName(): string
     {
         return $this->serviceName;
     }

--- a/src/Contexts/BTFContext.php
+++ b/src/Contexts/BTFContext.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace AndrewSvirin\Ebics\Contexts;
+
+/**
+ * Class BTFContext context container for BTD orders - requires EBICS 3.0
+ * 
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @author Andrew Svirin
+ */
+class BTFContext
+{
+    /**
+     * @var string
+     */
+    private $serviceName;
+
+    /**
+     * @var string
+     */
+    private $msgName;
+
+    /**
+     * @var string
+     */
+    private $scope;
+
+    /**
+     * @var string
+     */
+    private $serviceOption;
+
+    /**
+     * @var string
+     */
+    private $containerFlag;
+
+    /**
+     * @var string
+     */
+    private $msgNameVariant;
+
+    /**
+     * @var string
+     */
+    private $msgNameVersion;
+
+    /**
+     * @var string
+     */
+    private $msgNameFormat;
+
+    public function setServiceName(string $serviceName): BTFContext
+    {
+        $this->serviceName = $serviceName;
+
+        return $this;
+    }
+
+    public function getServiceName(): string
+    {
+        return $this->serviceName;
+    }
+
+    public function setMsgName(string $msgName): BTFContext
+    {
+        $this->msgName = $msgName;
+
+        return $this;
+    }
+
+    public function getMsgName(): string
+    {
+        return $this->msgName;
+    }
+
+    public function setScope(string $scope): BTFContext
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+
+    public function getScope(): ?string
+    {
+        return $this->scope;
+    }
+
+    public function setServiceOption(string $serviceOption): BTFContext
+    {
+        $this->serviceOption = $serviceOption;
+
+        return $this;
+    }
+
+    public function getServiceOption(): ?string
+    {
+        return $this->serviceOption;
+    }
+
+    public function setContainerFlag(string $containerFlag): BTFContext
+    {
+        $this->containerFlag = $containerFlag;
+
+        return $this;
+    }
+
+    public function getContainerFlag(): ?string
+    {
+        return $this->containerFlag;
+    }
+
+    public function setMsgNameVariant(string $msgNameVariant): BTFContext
+    {
+        $this->msgNameVariant = $msgNameVariant;
+
+        return $this;
+    }
+
+    public function getMsgNameVariant(): ?string
+    {
+        return $this->msgNameVariant;
+    }
+
+    public function setMsgNameVersion(string $msgNameVersion): BTFContext
+    {
+        $this->msgNameVersion = $msgNameVersion;
+
+        return $this;
+    }
+
+    public function getMsgNameVersion(): ?string
+    {
+        return $this->msgNameVersion;
+    }
+
+    public function setMsgNameFormat(string $msgNameFormat): BTFContext
+    {
+        $this->msgNameFormat = $msgNameFormat;
+
+        return $this;
+    }
+
+    public function getMsgNameFormat(): ?string
+    {
+        return $this->msgNameFormat;
+    }
+
+}

--- a/src/Contexts/BTFContext.php
+++ b/src/Contexts/BTFContext.php
@@ -57,7 +57,7 @@ class BTFContext
         return $this;
     }
 
-    public function getServiceName(): string
+    public function getServiceName(): ?string
     {
         return $this->serviceName;
     }

--- a/src/Contexts/RequestContext.php
+++ b/src/Contexts/RequestContext.php
@@ -94,19 +94,9 @@ class RequestContext
     private $signatureData;
 
     /**
-     * @var string
+     * @var BTFContext
      */
-    private $serviceName;
-
-    /**
-     * @var string
-     */
-    private $scope;
-
-    /**
-     * @var string
-     */
-    private $msgName;
+    private $btfContext;
 
     public function setBank(Bank $bank): RequestContext
     {
@@ -288,39 +278,15 @@ class RequestContext
         return $this->signatureData;
     }
 
-    public function setServiceName(string $serviceName): RequestContext
+    public function setBTFContext(BTFContext $btfContext): RequestContext
     {
-        $this->serviceName = $serviceName;
+        $this->btfContext = $btfContext;
 
         return $this;
     }
 
-    public function getServiceName(): string
+    public function getBTFContext(): BTFContext
     {
-        return $this->serviceName;
-    }
-
-    public function setScope(string $scope): RequestContext
-    {
-        $this->scope = $scope;
-
-        return $this;
-    }
-
-    public function getScope(): string
-    {
-        return $this->scope;
-    }
-
-    public function setMsgName(string $msgName): RequestContext
-    {
-        $this->msgName = $msgName;
-
-        return $this;
-    }
-
-    public function getMsgName(): string
-    {
-        return $this->msgName;
+        return $this->btfContext;
     }
 }

--- a/src/Contracts/EbicsClientInterface.php
+++ b/src/Contracts/EbicsClientInterface.php
@@ -2,6 +2,7 @@
 
 namespace AndrewSvirin\Ebics\Contracts;
 
+use AndrewSvirin\Ebics\Contexts\BTFContext;
 use AndrewSvirin\Ebics\Models\Http\Response;
 use DateTimeInterface;
 
@@ -53,9 +54,7 @@ interface EbicsClientInterface
      * @requires Ebics 3.0
      */
     public function BTD(
-        string $serviceName,
-        string $scope,
-        string $msgName,
+        BTFContext $btfContext,
         DateTimeInterface $dateTime = null,
         DateTimeInterface $startDateTime = null,
         DateTimeInterface $endDateTime = null

--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -2,6 +2,7 @@
 
 namespace AndrewSvirin\Ebics;
 
+use AndrewSvirin\Ebics\Contexts\BTFContext;
 use AndrewSvirin\Ebics\Contracts\EbicsClientInterface;
 use AndrewSvirin\Ebics\Contracts\HttpClientInterface;
 use AndrewSvirin\Ebics\Contracts\OrderDataInterface;
@@ -202,9 +203,7 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function BTD(
-        string $serviceName,
-        string $scope,
-        string $msgName,
+        BTFContext $btfContext,
         DateTimeInterface $dateTime = null,
         DateTimeInterface $startDateTime = null,
         DateTimeInterface $endDateTime = null
@@ -214,9 +213,7 @@ final class EbicsClient implements EbicsClientInterface
         }
         $request = $this->requestFactory->createBTD(
             $dateTime,
-            $serviceName,
-            $scope,
-            $msgName,
+            $btfContext,
             $startDateTime,
             $endDateTime
         );

--- a/src/Factories/RequestFactory.php
+++ b/src/Factories/RequestFactory.php
@@ -12,6 +12,7 @@ use AndrewSvirin\Ebics\Builders\Request\RequestBuilder;
 use AndrewSvirin\Ebics\Builders\Request\StaticBuilder;
 use AndrewSvirin\Ebics\Builders\Request\TransferReceiptBuilder;
 use AndrewSvirin\Ebics\Builders\Request\XmlBuilder;
+use AndrewSvirin\Ebics\Contexts\BTFContext;
 use AndrewSvirin\Ebics\Contexts\RequestContext;
 use AndrewSvirin\Ebics\Contracts\OrderDataInterface;
 use AndrewSvirin\Ebics\Contracts\SignatureInterface;
@@ -578,9 +579,7 @@ abstract class RequestFactory
      */
     public function createBTD(
         DateTimeInterface $dateTime,
-        string $serviceName,
-        string $scope,
-        string $msgName,
+        BTFContext $btfContext,
         DateTimeInterface $startDateTime = null,
         DateTimeInterface $endDateTime = null
     ): Request {
@@ -589,9 +588,7 @@ abstract class RequestFactory
             ->setUser($this->user)
             ->setKeyRing($this->keyRing)
             ->setDateTime($dateTime)
-            ->setServiceName($serviceName)
-            ->setScope($scope)
-            ->setMsgName($msgName)
+            ->setBTFContext($btfContext)
             ->setStartDateTime($startDateTime)
             ->setEndDateTime($endDateTime);
 
@@ -611,9 +608,7 @@ abstract class RequestFactory
                                 $this
                                     ->addOrderType($orderDetailsBuilder, 'BTD')
                                     ->addBTDOrderParams(
-                                        $context->getServiceName(),
-                                        $context->getScope(),
-                                        $context->getMsgName(),
+                                        $context->getBTFContext(),
                                         $context->getStartDateTime(),
                                         $context->getEndDateTime()
                                     );


### PR DESCRIPTION
Hello Andrew,

in EBICS 3.0, you can pass multiple parameters for BTD and BTU requests.
In order to lighten BTD method signature, I've created a BTFContext class that will contains all the mandatory and optionnal params.

More info on those required / optionnal params here :
https://docs.axway.com/bundle/EBICSGateway_330_AdministratorsGuide_allOS_en_HTML5/page/Content/AdminGuide/overview/c_ebics_std_about.htm#ebics_version_3.0

Cheers