### PR TITLE
implement batch booking option for SEPA SCT and SEPA SDD

### DIFF
--- a/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
@@ -34,10 +34,18 @@ class CustomerCreditTransferBuilder
         $this->randomService = new RandomService();
     }
 
+    /**
+     * @param string $debitorFinInstBIC
+     * @param string $debitorIBAN
+     * @param string $debitorName
+     * @param bool $batchBooking By deactivating the batch booking procedure, you request your credit institution to book each transaction within this order separately.
+     * @return $this
+     */
     public function createInstance(
         string $debitorFinInstBIC,
         string $debitorIBAN,
-        string $debitorName
+        string $debitorName,
+        bool $batchBooking = true
     ): CustomerCreditTransferBuilder {
         $this->instance = new CustomerCreditTransfer();
         $now = new DateTime();
@@ -97,6 +105,10 @@ class CustomerCreditTransferBuilder
         $xmlPmtMtd = $this->instance->createElement('PmtMtd');
         $xmlPmtMtd->nodeValue = 'TRF';
         $xmlPmtInf->appendChild($xmlPmtMtd);
+
+        $xmlBtchBookg = $this->instance->createElement('BtchBookg');
+        $xmlBtchBookg->nodeValue = (string) $batchBooking;
+        $xmlPmtInf->appendChild($xmlBtchBookg);
 
         $xmlNbOfTxs = $this->instance->createElement('NbOfTxs');
         $xmlNbOfTxs->nodeValue = '0';

--- a/src/Builders/CustomerDirectDebit/CustomerDirectDebitBuilder.php
+++ b/src/Builders/CustomerDirectDebit/CustomerDirectDebitBuilder.php
@@ -34,10 +34,18 @@ class CustomerDirectDebitBuilder
         $this->randomService = new RandomService();
     }
 
+    /**
+     * @param string $creditorFinInstBIC
+     * @param string $creditorIBAN
+     * @param string $creditorName
+     * @param bool $batchBooking By deactivating the batch booking procedure, you request your credit institution to book each transaction within this order separately.
+     * @return $this
+     */
     public function createInstance(
         string $creditorFinInstBIC,
         string $creditorIBAN,
-        string $creditorName
+        string $creditorName,
+        bool $batchBooking = true
     ): CustomerDirectDebitBuilder {
         $this->instance = new CustomerDirectDebit();
         $now = new DateTime();
@@ -97,6 +105,10 @@ class CustomerDirectDebitBuilder
         $xmlPmtMtd = $this->instance->createElement('PmtMtd');
         $xmlPmtMtd->nodeValue = 'DD';
         $xmlPmtInf->appendChild($xmlPmtMtd);
+
+        $xmlBtchBookg = $this->instance->createElement('BtchBookg');
+        $xmlBtchBookg->nodeValue = (string) $batchBooking;
+        $xmlPmtInf->appendChild($xmlBtchBookg);
 
         $xmlNbOfTxs = $this->instance->createElement('NbOfTxs');
         $xmlNbOfTxs->nodeValue = '0';


### PR DESCRIPTION
Disabling the SEPA Batch Booking flag advices your bank to book each transaction for his own.

Implemented for:
* SEPA Credit Transfer (SCT)
* SEPA Direct Debit (SDD)

Default Value for backwards compatibility:
`true`