### PR TITLE
remove outdated telefax order procedure

### DIFF
--- a/src/Factories/RequestFactoryV2.php
+++ b/src/Factories/RequestFactoryV2.php
@@ -54,7 +54,7 @@ class RequestFactoryV2 extends RequestFactory
                 $orderAttribute = OrderDetailsBuilder::ORDER_ATTRIBUTE_DZNNN;
                 break;
             default:
-                $orderAttribute = OrderDetailsBuilder::ORDER_ATTRIBUTE_DZHNN;
+                $orderAttribute = OrderDetailsBuilder::ORDER_ATTRIBUTE_OZHNN;
         }
 
         return $orderDetailsBuilder


### PR DESCRIPTION
This pull request fixes an error which occurs since version v1.8.0 

The order attribute `DZHNN` was used for manual telefax order approval.
In Version v1.7.9 and earlier the correct attribute `OZHNN` was already present.