### PR TITLE
remove wrong utf8 encode

### DIFF
--- a/src/Models/Data.php
+++ b/src/Models/Data.php
@@ -28,7 +28,6 @@ abstract class Data extends DOMDocument implements DataInterface
             $content
         );
         $content = str_replace(["\n", "\r", "\t"], '', $content);
-        $content = utf8_encode($content);
         $content = trim($content);
 
         return $content;


### PR DESCRIPTION
This PR removes already utf8 encoded xml content

Tested with real data for three german banks:
* SCT
* CIP
* SDD

