### PR TITLE
Add bank account report transaction Z52

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ try {
 | C52         | Download the bank account report in Camt.052 format.                                                              |
 | C53         | Download the bank account statement in Camt.053 format.                                                           |
 | C54         | Download Debit Credit Notification (DTI).                                                                         |
+| Z52         | Download the bank account report in Camt.052 format (i.e Switzerland financial services).                         |
 | Z53         | Download the bank account statement in Camt.053 format (i.e Switzerland financial services).                      |
 | Z54         | Download the bank account statement in Camt.054 format (i.e available in Switzerland).                            |
 | CCT         | Upload initiation of the credit transfer per Single Euro Payments Area.                                           |

--- a/src/Contracts/EbicsClientInterface.php
+++ b/src/Contracts/EbicsClientInterface.php
@@ -185,6 +185,21 @@ interface EbicsClientInterface
     // @codingStandardsIgnoreEnd
 
     /**
+     * Download the bank account report in Camt.052 format (i.e Switzerland financial services).
+     * @param DateTimeInterface|null $dateTime
+     * @param DateTimeInterface|null $startDateTime the start date of requested transactions
+     * @param DateTimeInterface|null $endDateTime the end date of requested transactions
+     * @return DownloadOrderResult
+     */
+    // @codingStandardsIgnoreStart
+    public function Z52(
+        DateTimeInterface $dateTime = null,
+        DateTimeInterface $startDateTime = null,
+        DateTimeInterface $endDateTime = null
+    ): DownloadOrderResult;
+    // @codingStandardsIgnoreEnd
+
+    /**
      * Download the bank account statement in Camt.053 format (i.e Switzerland financial services).
      * @param DateTimeInterface|null $dateTime
      * @param DateTimeInterface|null $startDateTime the start date of requested transactions

--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -591,6 +591,36 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     // @codingStandardsIgnoreStart
+    public function Z52(
+        DateTimeInterface $dateTime = null,
+        DateTimeInterface $startDateTime = null,
+        DateTimeInterface $endDateTime = null
+    ): DownloadOrderResult {
+        // @codingStandardsIgnoreEnd
+        if (null === $dateTime) {
+            $dateTime = new DateTime();
+        }
+
+        $transaction = $this->downloadTransaction(
+            function ($segmentNumber, $isLastSegment) use ($dateTime, $startDateTime, $endDateTime) {
+                return $this->requestFactory->createZ52(
+                    $dateTime,
+                    $startDateTime,
+                    $endDateTime,
+                    $segmentNumber,
+                    $isLastSegment
+                );
+            }
+        );
+
+        return $this->createDownloadOrderResult($transaction, 'files');
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exceptions\EbicsException
+     */
+    // @codingStandardsIgnoreStart
     public function Z53(
         DateTimeInterface $dateTime = null,
         DateTimeInterface $startDateTime = null,
@@ -613,7 +643,7 @@ final class EbicsClient implements EbicsClientInterface
             }
         );
 
-        return $this->createDownloadOrderResult($transaction, 'text');
+        return $this->createDownloadOrderResult($transaction, 'files');
     }
 
     /**

--- a/src/Factories/RequestFactory.php
+++ b/src/Factories/RequestFactory.php
@@ -1107,6 +1107,64 @@ abstract class RequestFactory
     /**
      * @throws EbicsException
      */
+    public function createZ52(
+        DateTimeInterface $dateTime,
+        DateTimeInterface $startDateTime = null,
+        DateTimeInterface $endDateTime = null,
+        int $segmentNumber = null,
+        bool $isLastSegment = null
+    ): Request {
+        $context = (new RequestContext())
+            ->setBank($this->bank)
+            ->setUser($this->user)
+            ->setKeyRing($this->keyRing)
+            ->setDateTime($dateTime)
+            ->setStartDateTime($startDateTime)
+            ->setEndDateTime($endDateTime)
+            ->setSegmentNumber($segmentNumber)
+            ->setIsLastSegment($isLastSegment);
+
+        $request = $this
+            ->createRequestBuilderInstance()
+            ->addContainerSecured(function (XmlBuilder $builder) use ($context) {
+                $builder->addHeader(function (HeaderBuilder $builder) use ($context) {
+                    $builder->addStatic(function (StaticBuilder $builder) use ($context) {
+                        $builder
+                            ->addHostId($context->getBank()->getHostId())
+                            ->addRandomNonce()
+                            ->addTimestamp($context->getDateTime())
+                            ->addPartnerId($context->getUser()->getPartnerId())
+                            ->addUserId($context->getUser()->getUserId())
+                            ->addProduct('Ebics client PHP', 'de')
+                            ->addOrderDetails(function (OrderDetailsBuilder $orderDetailsBuilder) use ($context) {
+                                $this
+                                    ->addOrderType($orderDetailsBuilder, 'Z52')
+                                    ->addStandardOrderParams($context->getStartDateTime(), $context->getEndDateTime());
+                            })
+                            ->addBankPubKeyDigests(
+                                $context->getKeyRing()->getBankSignatureXVersion(),
+                                $this->digestResolver->digest($context->getKeyRing()->getBankSignatureX()),
+                                $context->getKeyRing()->getBankSignatureEVersion(),
+                                $this->digestResolver->digest($context->getKeyRing()->getBankSignatureE())
+                            )
+                            ->addSecurityMedium(StaticBuilder::SECURITY_MEDIUM_0000);
+                    })->addMutable(function (MutableBuilder $builder) use ($context) {
+                        $builder
+                            ->addTransactionPhase(MutableBuilder::PHASE_INITIALIZATION)
+                            ->addSegmentNumber($context->getSegmentNumber(), $context->getIsLastSegment());
+                    });
+                })->addBody();
+            })
+            ->popInstance();
+
+        $this->authSignatureHandler->handle($request);
+
+        return $request;
+    }
+
+    /**
+     * @throws EbicsException
+     */
     public function createZ53(
         DateTimeInterface $dateTime,
         DateTimeInterface $startDateTime = null,

--- a/tests/EbicsClientV2Test.php
+++ b/tests/EbicsClientV2Test.php
@@ -443,6 +443,35 @@ class EbicsClientV2Test extends AbstractEbicsTestCase
     /**
      * @dataProvider serversDataProvider
      *
+     * @group Z52
+     *
+     * @param int $credentialsId
+     * @param array $codes
+     * @param X509GeneratorInterface|null $x509Generator
+     *
+     * @covers
+     */
+    public function testZ52(int $credentialsId, array $codes, X509GeneratorInterface $x509Generator = null)
+    {
+        $client = $this->setupClientV2($credentialsId, $x509Generator, $codes['Z52']['fake']);
+
+        $this->assertExceptionCode($codes['Z52']['code']);
+        $z52 = $client->Z52();
+
+        $responseHandler = new ResponseHandlerV2();
+        $code = $responseHandler->retrieveH00XReturnCode($z52->getTransaction()->getLastSegment()->getResponse());
+        $reportText = $responseHandler->retrieveH00XReportText($z52->getTransaction()->getLastSegment()->getResponse());
+        $this->assertResponseOk($code, $reportText);
+
+        $code = $responseHandler->retrieveH00XReturnCode($z52->getTransaction()->getReceipt());
+        $reportText = $responseHandler->retrieveH00XReportText($z52->getTransaction()->getReceipt());
+
+        $this->assertResponseDone($code, $reportText);
+    }
+
+    /**
+     * @dataProvider serversDataProvider
+     *
      * @group Z53
      *
      * @param int $credentialsId
@@ -952,6 +981,7 @@ class EbicsClientV2Test extends AbstractEbicsTestCase
                     'PTK' => ['code' => null, 'fake' => false],
                     'VMK' => ['code' => '090003', 'fake' => false],
                     'STA' => ['code' => '090003', 'fake' => false],
+                    'Z52' => ['code' => '090005', 'fake' => false],
                     'Z53' => ['code' => '090005', 'fake' => false],
                     'Z54' => ['code' => '090005', 'fake' => false],
                     'C52' => ['code' => '090003', 'fake' => false],
@@ -1016,6 +1046,7 @@ class EbicsClientV2Test extends AbstractEbicsTestCase
                     'PTK' => ['code' => null, 'fake' => false],
                     'VMK' => ['code' => '090003', 'fake' => false],
                     'STA' => ['code' => '090003', 'fake' => false],
+                    'Z52' => ['code' => '090005', 'fake' => false],
                     'Z53' => ['code' => '090005', 'fake' => false],
                     'Z54' => ['code' => '090005', 'fake' => false],
                     'C52' => ['code' => '090003', 'fake' => false],
@@ -1050,6 +1081,7 @@ class EbicsClientV2Test extends AbstractEbicsTestCase
                     'PTK' => ['code' => null, 'fake' => false],
                     'VMK' => ['code' => '090005', 'fake' => false],
                     'STA' => ['code' => '090005', 'fake' => false],
+                    'Z52' => ['code' => '090005', 'fake' => false],
                     'Z53' => ['code' => '090005', 'fake' => false],
                     'Z54' => ['code' => '090005', 'fake' => false],
                     'C52' => ['code' => '090003', 'fake' => false],
@@ -1084,6 +1116,7 @@ class EbicsClientV2Test extends AbstractEbicsTestCase
                     'PTK' => ['code' => null, 'fake' => false],
                     'VMK' => ['code' => '090003', 'fake' => false],
                     'STA' => ['code' => '090003', 'fake' => false],
+                    'Z52' => ['code' => '090005', 'fake' => false],
                     'Z53' => ['code' => '090005', 'fake' => false],
                     'Z54' => ['code' => '090005', 'fake' => false],
                     'C52' => ['code' => '090003', 'fake' => false],


### PR DESCRIPTION
This pull request adds support for the bank report transaction Z52 for swiss financial institutions.
Furthermore I had issues while fetching bank statements with transaction Z53. The change from 'text' to 'files' fixed this problem (Postfinance).