### PR TITLE
fix charset in Content-Type header

### DIFF
--- a/src/Services/HttpClient.php
+++ b/src/Services/HttpClient.php
@@ -30,7 +30,7 @@ final class HttpClient implements HttpClientInterface
             throw new RuntimeException('Can not create curl.');
         }
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            'Content-Type: text/xml; charset=ISO-8859-1',
+            'Content-Type: text/xml; charset=UTF-8',
         ]);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);


### PR DESCRIPTION
The xml document itself (sent in the body of the request) has the declaration `<?xml version='1.0' encoding='utf-8'?>`, which is in contradiction with the charset declared in the `Content-Type` header.