### PR TITLE
New PsrHttpClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
   "require-dev": {
     "andrew-svirin/cfonb-php": "dev-master",
     "andrew-svirin/mt942-php": "dev-master",
+    "berlioz/http-message": "^1.2",
     "mpdf/mpdf": "^8",
     "phpseclib/phpseclib": "~2.0.35",
     "phpstan/phpstan": "^1",

--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,10 @@
     "ext-bcmath": "*",
     "ext-curl": "*",
     "ext-dom": "*",
+    "ext-json": "*",
     "ext-openssl": "*",
     "ext-zip": "*",
-    "ext-zlib": "*",
-    "ext-json": "*"
+    "ext-zlib": "*"
   },
   "require-dev": {
     "mpdf/mpdf": "^8",
@@ -52,7 +52,9 @@
   "suggest": {
     "andrew-svirin/cfonb-php": "If you need to parse format CFONB from FDL requests.",
     "andrew-svirin/mt942-php": "If you need to parse format MT942 from VMK, STA requests.",
-    "mpdf/mpdf": "If you need to generate PDF file letter for Bank."
+    "mpdf/mpdf": "If you need to generate PDF file letter for Bank.",
+    "psr/http-client": "If you want use the PsrHttpClient",
+    "psr/http-factory": "If you want use the PsrHttpClient"
   },
   "config": {
     "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,14 @@
     "ext-zlib": "*"
   },
   "require-dev": {
-    "mpdf/mpdf": "^8",
-    "phpstan/phpstan": "^1",
-    "phpunit/phpunit": "^9",
     "andrew-svirin/cfonb-php": "dev-master",
     "andrew-svirin/mt942-php": "dev-master",
+    "mpdf/mpdf": "^8",
     "phpseclib/phpseclib": "~2.0.35",
+    "phpstan/phpstan": "^1",
+    "phpunit/phpunit": "^9",
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.0",
     "squizlabs/php_codesniffer": "^3"
   },
   "autoload": {

--- a/src/Services/PsrHttpClient.php
+++ b/src/Services/PsrHttpClient.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AndrewSvirin\Ebics\Services;
+
+use AndrewSvirin\Ebics\Contracts\HttpClientInterface;
+use AndrewSvirin\Ebics\Models\Http\Request;
+use AndrewSvirin\Ebics\Models\Http\Response;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use RuntimeException;
+
+class PsrHttpClient implements HttpClientInterface
+{
+    /** @var ClientInterface */
+    private $client;
+    /** @var RequestFactoryInterface */
+    private $requestFactory;
+
+    public function __construct(
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory
+    ) {
+        $this->client = $client;
+        $this->requestFactory = $requestFactory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function post(string $url, Request $request): Response
+    {
+        // Construct PSR request
+        $psrRequest = $this->requestFactory->createRequest('POST', $url);
+        $psrRequest = $psrRequest->withHeader('Content-Type', 'text/xml; charset=UTF-8');
+
+        // Call PSR HTTP client
+        $psrResponse = $this->client->sendRequest($psrRequest);
+        $contents = $psrResponse->getBody()->getContents();
+
+        if (empty($contents)) {
+            throw new RuntimeException('Response is empty.');
+        }
+
+        $response = new Response();
+        $response->loadXML($contents);
+
+        return $response;
+    }
+}

--- a/src/Services/PsrHttpClient.php
+++ b/src/Services/PsrHttpClient.php
@@ -9,6 +9,14 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use RuntimeException;
 
+/**
+ * PSR http client.
+ *
+ * This client allows to use a PSR http client instead of the internal HttpClient.
+ *
+ * @license http://www.opensource.org/licenses/mit-license.html  MIT License
+ * @author Ronan Giron
+ */
 final class PsrHttpClient implements HttpClientInterface
 {
     /** @var ClientInterface */

--- a/src/Services/PsrHttpClient.php
+++ b/src/Services/PsrHttpClient.php
@@ -9,7 +9,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use RuntimeException;
 
-class PsrHttpClient implements HttpClientInterface
+final class PsrHttpClient implements HttpClientInterface
 {
     /** @var ClientInterface */
     private $client;

--- a/tests/Services/PsrHttpClientTest.php
+++ b/tests/Services/PsrHttpClientTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace AndrewSvirin\Ebics\Tests\Services;
+
+use AndrewSvirin\Ebics\Models\Http\Request;
+use AndrewSvirin\Ebics\Services\PsrHttpClient;
+use AndrewSvirin\Ebics\Tests\AbstractEbicsTestCase;
+use Berlioz\Http\Message\HttpFactory;
+use Berlioz\Http\Message\Response;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class PsrHttpClientTest extends AbstractEbicsTestCase
+{
+    public function testPost(): void
+    {
+        $client = new PsrHttpClient(
+            $psrClient = new class implements ClientInterface {
+                /** @var RequestInterface */
+                public $request;
+
+                public function sendRequest(RequestInterface $request): ResponseInterface
+                {
+                    $this->request = $request;
+                    return new Response("<?xml version='1.0' encoding='utf-8'?><ResponseTest/>");
+                }
+            },
+            new HttpFactory(),
+            new HttpFactory()
+        );
+
+        $request = new Request();
+        $request->loadXML("<?xml version='1.0' encoding='utf-8'?><RequestTest/>");
+        $response = $client->post('fake', $request);
+
+        $this->assertEquals(
+            "<?xml version='1.0' encoding='utf-8'?><ResponseTest/>",
+            $response->getContent()
+        );
+        $this->assertEquals(
+            ['Content-Type' => ['text/xml; charset=UTF-8']],
+            $psrClient->request->getHeaders()
+        );
+        $this->assertEquals(
+            $request->getContent(),
+            $psrClient->request->getBody()->getContents()
+        );
+    }
+}


### PR DESCRIPTION
This pull request allow to use an HTTP client which implements `psr/http-client` package.

This is useful for tracing and debugging exchanges between servers.

Very easy to use:

```php
$ebicsClient = new EbicsClient(...);
$ebicsClient->setHttpClient(new PsrHttpClient($myPsrClient));
```

The `PsrHttpClient` class accepts only one argument, it's a PSR Http client.

---

Related to this pull request and existing unit tests, another way is to use a HAR file with a PHP client:
https://github.com/BerliozFramework/HttpClient/tree/2.x#haradapter