### PR TITLE
Fix x509 generator options

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ use AndrewSvirin\Ebics\Models\X509\AbstractX509Generator;
 
 class MyCompanyX509Generator extends AbstractX509Generator
 {
-    public function getCertificateOptions(array $options = []) : array {
+    protected function getCertificateOptions() : array {
         return [
              'subject' => [
                 'DN' => [

--- a/src/Models/X509/AbstractX509Generator.php
+++ b/src/Models/X509/AbstractX509Generator.php
@@ -42,11 +42,6 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
     private $x509Factory;
 
     /**
-     * @var array
-     */
-    private $certificateOptions;
-
-    /**
      * @var RandomService
      */
     private $randomService;
@@ -61,24 +56,13 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
     }
 
     /**
-     * @param array $certificateOptions
-     */
-    public function setCertificateOptions(array $certificateOptions): void
-    {
-        $this->certificateOptions = $certificateOptions;
-    }
-
-    /**
      * Get certificate options
      *
      * @return array the certificate options
      *
      * @see X509 options
      */
-    protected function getCertificateOptions(): array
-    {
-        return $this->certificateOptions;
-    }
+    abstract protected function getCertificateOptions(): array;
 
     /**
      * @inheritDoc

--- a/src/Models/X509/AbstractX509Generator.php
+++ b/src/Models/X509/AbstractX509Generator.php
@@ -42,6 +42,11 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
     private $x509Factory;
 
     /**
+     * @var array
+     */
+    private $certificateOptions;
+
+    /**
      * @var RandomService
      */
     private $randomService;
@@ -53,6 +58,16 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
         $this->x509EndDate = (new DateTime())->modify('+1 year');
         $this->randomService = new RandomService();
         $this->serialNumber = $this->generateSerialNumber();
+        $this->certificateOptions = [];
+    }
+
+    /**
+     * @param array $certificateOptions
+     * @deprecated 2.1 No longer used by internal code and not recommended. Extend getCertificateOptions() method.
+     */
+    public function setCertificateOptions(array $certificateOptions): void
+    {
+        $this->certificateOptions = $certificateOptions;
     }
 
     /**
@@ -62,7 +77,10 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
      *
      * @see X509 options
      */
-    abstract protected function getCertificateOptions(): array;
+    protected function getCertificateOptions(): array
+    {
+        return $this->certificateOptions;
+    }
 
     /**
      * @inheritDoc

--- a/src/Models/X509/AbstractX509Generator.php
+++ b/src/Models/X509/AbstractX509Generator.php
@@ -43,8 +43,9 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
 
     /**
      * @var array
+     * @deprecated 2.1 No longer used by internal code and not recommended. Extend getCertificateOptions() method.
      */
-    protected $certificateOptions;
+    protected $certificateOptions = [];
 
     /**
      * @var RandomService
@@ -58,7 +59,6 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
         $this->x509EndDate = (new DateTime())->modify('+1 year');
         $this->randomService = new RandomService();
         $this->serialNumber = $this->generateSerialNumber();
-        $this->certificateOptions = [];
     }
 
     /**
@@ -187,14 +187,7 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
         ];
 
         $options = array_merge_recursive($defaultCertificateOptions, $typeCertificateOptions);
-
-        $certificateOptions = $this->getCertificateOptions();
-        // Prevent not same options between property and getter method
-        if ($certificateOptions !== $this->certificateOptions) {
-            $options = $this->mergeCertificateOptions($options, $this->certificateOptions);
-        }
-
-        $options = $this->mergeCertificateOptions($options, $certificateOptions);
+        $options = $this->mergeCertificateOptions($options, $this->getCertificateOptions());
 
         $signatureAlgorithm = 'sha256WithRSAEncryption';
 

--- a/src/Models/X509/AbstractX509Generator.php
+++ b/src/Models/X509/AbstractX509Generator.php
@@ -44,7 +44,7 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
     /**
      * @var array
      */
-    private $certificateOptions;
+    protected $certificateOptions;
 
     /**
      * @var RandomService
@@ -188,7 +188,13 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
 
         $options = array_merge_recursive($defaultCertificateOptions, $typeCertificateOptions);
 
-        $options = $this->mergeCertificateOptions($options, $this->getCertificateOptions());
+        $certificateOptions = $this->getCertificateOptions();
+        // Prevent not same options between property and getter method
+        if ($certificateOptions !== $this->certificateOptions) {
+            $options = $this->mergeCertificateOptions($options, $this->certificateOptions);
+        }
+
+        $options = $this->mergeCertificateOptions($options, $certificateOptions);
 
         $signatureAlgorithm = 'sha256WithRSAEncryption';
 

--- a/src/Models/X509/AbstractX509Generator.php
+++ b/src/Models/X509/AbstractX509Generator.php
@@ -186,7 +186,7 @@ abstract class AbstractX509Generator implements X509GeneratorInterface
 
         $options = array_merge_recursive($defaultCertificateOptions, $typeCertificateOptions);
 
-        $options = $this->mergeCertificateOptions($options, $this->certificateOptions);
+        $options = $this->mergeCertificateOptions($options, $this->getCertificateOptions());
 
         $signatureAlgorithm = 'sha256WithRSAEncryption';
 

--- a/src/Models/X509/BankX509Generator.php
+++ b/src/Models/X509/BankX509Generator.php
@@ -14,6 +14,11 @@ use LogicException;
 final class BankX509Generator extends AbstractX509Generator
 {
     /**
+     * @var array
+     */
+    private $certificateOptions;
+
+    /**
      * Set certificate options by Bank.
      */
     public function setCertificateOptionsByBank(Bank $bank): void
@@ -21,7 +26,7 @@ final class BankX509Generator extends AbstractX509Generator
         $countryName = $this->resolveCountryName($bank->getUrl());
         $domainName = $this->resolveDomainName($bank->getUrl());
         $establishmentName = $this->resolveEstablishmentName($bank->getUrl());
-        $this->setCertificateOptions([
+        $this->certificateOptions = [
             'subject' => [
                 'DN' => [
                     'id-at-countryName' => $countryName,
@@ -34,7 +39,15 @@ final class BankX509Generator extends AbstractX509Generator
                     'id-at-commonName' => $establishmentName,
                 ],
             ],
-        ]);
+        ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getCertificateOptions(): array
+    {
+        return $this->certificateOptions;
     }
 
     /**

--- a/src/Models/X509/BankX509Generator.php
+++ b/src/Models/X509/BankX509Generator.php
@@ -14,11 +14,6 @@ use LogicException;
 final class BankX509Generator extends AbstractX509Generator
 {
     /**
-     * @var array
-     */
-    private $certificateOptions;
-
-    /**
      * Set certificate options by Bank.
      */
     public function setCertificateOptionsByBank(Bank $bank): void
@@ -40,14 +35,6 @@ final class BankX509Generator extends AbstractX509Generator
                 ],
             ],
         ];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    protected function getCertificateOptions(): array
-    {
-        return $this->certificateOptions;
     }
 
     /**

--- a/tests/Factories/X509/CreditSuisseX509Generator.php
+++ b/tests/Factories/X509/CreditSuisseX509Generator.php
@@ -10,10 +10,12 @@ use AndrewSvirin\Ebics\Models\X509\AbstractX509Generator;
  */
 class CreditSuisseX509Generator extends AbstractX509Generator
 {
-    public function __construct()
+    /**
+     * @inheritDoc
+     */
+    protected function getCertificateOptions(): array
     {
-        parent::__construct();
-        $this->setCertificateOptions([
+        return [
             'subject' => [
                 'DN' => [
                     'id-at-countryName' => 'DE',
@@ -26,6 +28,6 @@ class CreditSuisseX509Generator extends AbstractX509Generator
                     'id-at-commonName' => 'CreditSuisse Client',
                 ],
             ],
-        ]);
+        ];
     }
 }

--- a/tests/Factories/X509/SilarhiX509Generator.php
+++ b/tests/Factories/X509/SilarhiX509Generator.php
@@ -5,7 +5,6 @@ namespace AndrewSvirin\Ebics\Tests\Factories\X509;
 use AndrewSvirin\Ebics\Contracts\X509GeneratorInterface;
 use AndrewSvirin\Ebics\Models\X509\AbstractX509Generator;
 
-
 /**
  * Legacy X509 certificate generator @see X509GeneratorInterface.
  *
@@ -14,11 +13,12 @@ use AndrewSvirin\Ebics\Models\X509\AbstractX509Generator;
  */
 class SilarhiX509Generator extends AbstractX509Generator
 {
-
-    public function __construct()
+    /**
+     * @inheritDoc
+     */
+    protected function getCertificateOptions(): array
     {
-        parent::__construct();
-        $this->setCertificateOptions([
+        return [
             'subject' => [
                 'domain' => 'silarhi.fr',
                 'DN' => [
@@ -50,6 +50,6 @@ class SilarhiX509Generator extends AbstractX509Generator
                     'value' => ['id-kp-serverAuth', 'id-kp-clientAuth'],
                 ],
             ],
-        ]);
+        ];
     }
 }

--- a/tests/Factories/X509/WeBankX509Generator.php
+++ b/tests/Factories/X509/WeBankX509Generator.php
@@ -13,10 +13,12 @@ use AndrewSvirin\Ebics\Models\X509\AbstractX509Generator;
  */
 class WeBankX509Generator extends AbstractX509Generator
 {
-    public function __construct()
+    /**
+     * @inheritDoc
+     */
+    protected function getCertificateOptions(): array
     {
-        parent::__construct();
-        $this->setCertificateOptions([
+        return [
             'subject' => [
                 'DN' => [
                     'id-at-countryName' => 'FR',
@@ -29,6 +31,6 @@ class WeBankX509Generator extends AbstractX509Generator
                     'id-at-commonName' => 'Webank Client',
                 ],
             ],
-        ]);
+        ];
     }
 }

--- a/tests/Factories/X509/ZKBX509Generator.php
+++ b/tests/Factories/X509/ZKBX509Generator.php
@@ -10,10 +10,12 @@ use AndrewSvirin\Ebics\Models\X509\AbstractX509Generator;
  */
 class ZKBX509Generator extends AbstractX509Generator
 {
-    public function __construct()
+    /**
+     * @inheritDoc
+     */
+    protected function getCertificateOptions(): array
     {
-        parent::__construct();
-        $this->setCertificateOptions([
+        return [
             'subject' => [
                 'DN' => [
                     'id-at-countryName' => 'DE',
@@ -26,6 +28,6 @@ class ZKBX509Generator extends AbstractX509Generator
                     'id-at-commonName' => 'ZKB Client',
                 ],
             ],
-        ]);
+        ];
     }
 }


### PR DESCRIPTION
Example in `README.md` generate an error. Because the class try to merge a NULL value with the default array options.

```php
<?php

namespace App\Factories\X509;

use AndrewSvirin\Ebics\Models\X509\AbstractX509Generator;

class MyCompanyX509Generator extends AbstractX509Generator
{
    public function getCertificateOptions(array $options = []) : array {
        return [
             'subject' => [
                'DN' => [
                    'id-at-countryName' => 'FR',
                    'id-at-stateOrProvinceName' => 'State',
                    'id-at-localityName' => 'City',
                    'id-at-organizationName' => 'Your company',
                    'id-at-commonName' => 'yourwebsite.tld',
                    ]
                ],
                'extensions' => [
                    'id-ce-subjectAltName' => [
                    'value' => [
                        'dNSName' => '*.yourwebsite.tld',
                    ]
                ],
            ],
        ];
    }
}
```

Fix consist to call `getCertificateOptions()` instead of property.