### PR TITLE
$serverName needs to be initialized, otherwise creating a bank letter…

### DIFF
--- a/src/Models/Bank.php
+++ b/src/Models/Bank.php
@@ -28,7 +28,7 @@ final class Bank
     /**
      * The Server Name of the bank.
      */
-    private ?string $serverName;
+    private ?string $serverName = null;
 
     /**
      * The Server Version of the bank.


### PR DESCRIPTION
HtmlBankLetterFormatter.php calls $this->getServerName($bankLetter->getBank()) in line 118.

The code in getServerName:
```php
        if (empty($serverName = $bank->getServerName())) {
            return '--';
        }
```

explicity allows empty $serverNames.

However, if $bank->setServerName() has not been called before (like in the readme example), the
```php
$pdf = $ebicsBankLetter->formatBankLetter($bankLetter, $ebicsBankLetter->createPdfBankLetterFormatter());
```
code will fail with

```
PHP Fatal error:  Uncaught Error: Typed property AndrewSvirin\Ebics\Models\Bank::$serverName must not be accessed before initialization in /home/***/vendor/andrew-svirin/ebics-client-php/src/Models/Bank.php:101
Stack trace:
#0 /home/***/vendor/andrew-svirin/ebics-client-php/src/Services/BankLetter/Formatter/HtmlBankLetterFormatter.php(154): AndrewSvirin\Ebics\Models\Bank->getServerName()
#1 /home/***/vendor/andrew-svirin/ebics-client-php/src/Services/BankLetter/Formatter/HtmlBankLetterFormatter.php(118): AndrewSvirin\Ebics\Services\BankLetter\Formatter\HtmlBankLetterFormatter->getServerName()
#2 /home/***/vendor/andrew-svirin/ebics-client-php/src/Services/BankLetter/Formatter/PdfBankLetterFormatter.php(57): AndrewSvirin\Ebics\Services\BankLetter\Formatter\HtmlBankLetterFormatter->format()
#3 /home/***/vendor/andrew-svirin/ebics-client-php/src/EbicsBankLet in /home/***/vendor/andrew-svirin/ebics-client-php/src/Models/Bank.php on line 101
```

This pull request fixes bank letter creation by initializing Bank::serverName with null.
 
Alternatively
```php
return $this->serverName ?? null;
```
in Bank::getServerName()