### PR TITLE
Implementation for optional SEPA credit transfer purpose codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <img src="https://www.ebics.org/typo3conf/ext/siz_ebicsorg_base/Resources/Public/Images/ebics-logo.png" width="300">
 
 PHP library to communicate with a bank through EBICS protocol.  
-Supported PHP versions - PHP 7.2 - PHP 8.1  
+Supported PHP versions - PHP 7.2 - PHP 8.3  
 Support Ebics server versions: 2.4 (partially), 2.5 (default), 3.0
 
 ## License

--- a/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
@@ -179,6 +179,17 @@ final class CustomerCreditTransferBuilder
         return $this;
     }
 
+    /**
+     * @param string $creditorFinInstBIC
+     * @param string $creditorIBAN
+     * @param string $creditorName
+     * @param float $amount
+     * @param string $currency
+     * @param string $purpose
+     * @param string|null $endToEndId
+     * @param string|null $purposeCode Optional Purpose Code - e.G. BENE BONU CBFF CHAR GOVT PENS SALA SSBE
+     * @return CustomerCreditTransferBuilder
+     */
     public function addTransaction(
         string $creditorFinInstBIC,
         string $creditorIBAN,
@@ -186,7 +197,8 @@ final class CustomerCreditTransferBuilder
         float $amount,
         string $currency,
         string $purpose,
-        string $endToEndId = null
+        string $endToEndId = null,
+        string $purposeCode = null
     ): CustomerCreditTransferBuilder {
         $xpath = $this->prepareXPath($this->instance);
         $nbOfTxsList = $xpath->query('//CstmrCdtTrfInitn/PmtInf/NbOfTxs');
@@ -246,6 +258,15 @@ final class CustomerCreditTransferBuilder
         $xmlIBAN = $this->instance->createElement('IBAN');
         $xmlIBAN->nodeValue = $creditorIBAN;
         $xmlId->appendChild($xmlIBAN);
+
+        if ($purposeCode) {
+            $xmlPurp = $this->instance->createElement('Purp');
+            $xmlCdtTrfTxInf->appendChild($xmlPurp);
+
+            $xmlCd = $this->instance->createElement('Cd');
+            $xmlCd->nodeValue = $purposeCode;
+            $xmlPurp->appendChild($xmlCd);
+        }
 
         $xmlRmtInf = $this->instance->createElement('RmtInf');
         $xmlCdtTrfTxInf->appendChild($xmlRmtInf);

--- a/src/Builders/CustomerCreditTransfer/CustomerInstantCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerInstantCreditTransferBuilder.php
@@ -184,7 +184,8 @@ final class CustomerInstantCreditTransferBuilder
      * @param float $amount
      * @param string $currency
      * @param string $purpose
-     * @param string $endToEndId
+     * @param string|null $endToEndId
+     * @param string|null $purposeCode Optional Purpose Code - e.G. BENE BONU CBFF CHAR GOVT PENS SALA SSBE
      * @return CustomerInstantCreditTransferBuilder
      */
     public function addTransaction(
@@ -194,7 +195,8 @@ final class CustomerInstantCreditTransferBuilder
         float $amount,
         string $currency,
         string $purpose,
-        string $endToEndId
+        string $endToEndId = null,
+        string $purposeCode = null
     ): CustomerInstantCreditTransferBuilder {
         $xpath = $this->prepareXPath($this->instance);
         $nbOfTxsList = $xpath->query('//CstmrCdtTrfInitn/PmtInf/NbOfTxs');
@@ -254,6 +256,15 @@ final class CustomerInstantCreditTransferBuilder
         $xmlIBAN = $this->instance->createElement('IBAN');
         $xmlIBAN->nodeValue = $creditorIBAN;
         $xmlId->appendChild($xmlIBAN);
+
+        if ($purposeCode) {
+            $xmlPurp = $this->instance->createElement('Purp');
+            $xmlCdtTrfTxInf->appendChild($xmlPurp);
+
+            $xmlCd = $this->instance->createElement('Cd');
+            $xmlCd->nodeValue = $purposeCode;
+            $xmlPurp->appendChild($xmlCd);
+        }
 
         $xmlRmtInf = $this->instance->createElement('RmtInf');
         $xmlCdtTrfTxInf->appendChild($xmlRmtInf);


### PR DESCRIPTION
This pull requests implement the SEPA purpose codes to flag transactions for specific payment types, like salary payments.

Full list of SEPA codes:
https://wiki.windata.de/index.php?title=Purpose-SEPA-Codes

Additional optional parameter `$purposeCode` added to the credit transfer builder. 
Fully backwards compatible 

---
Additional changes:
* Added PHP 8.3 to readme (tested in production)
* `$endToEndId` in CustomerInstantCreditTransferBuilder is null on default (same behaviour as CustomerCreditTransferBuilder)

---
Generated SEPA XML Sample for **SALA** Code:

```
<CdtTrfTxInf>
    <PmtId>
        <EndToEndId>**********</EndToEndId>
    </PmtId>
    <Amt>
        <InstdAmt Ccy="EUR">100.00</InstdAmt>
    </Amt>
    <Cdtr>
        <Nm>Payment Receiver</Nm>
    </Cdtr>
    <CdtrAcct>
        <Id>
            <IBAN>DE****************</IBAN>
        </Id>
    </CdtrAcct>
    <Purp>
        <Cd>SALA</Cd>
    </Purp>
    <RmtInf>
        <Ustrd>Purpose Description</Ustrd>
    </RmtInf>
</CdtTrfTxInf>
```