### PR TITLE
implementation for schema namespace definition like SDD

### DIFF
--- a/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
@@ -27,7 +27,6 @@ final class CustomerCreditTransferBuilder
     }
 
     /**
-     * @param string $schema has next formula urn:iso:std:iso:20022:tech:xsd:msgName.001.msgNameVersion
      * @param string $debitorFinInstBIC
      * @param string $debitorIBAN
      * @param string $debitorName
@@ -38,17 +37,18 @@ final class CustomerCreditTransferBuilder
      * least for 15 days. Used for rejecting duplicated transactions (max length: 35 characters)
      * @param string|null $paymentReference Overwrite default payment reference -
      * visible on creditors bank statement (max length: 35 characters)
+     * @param string $schema default namespace schema urn:iso:std:iso:20022:tech:xsd:pain.001.001.03
      * @return $this
      */
     public function createInstance(
-        string $schema,
         string $debitorFinInstBIC,
         string $debitorIBAN,
         string $debitorName,
         DateTime $executionDate = null,
         bool $batchBooking = true,
         string $msgId = null,
-        string $paymentReference = null
+        string $paymentReference = null,
+        string $schema = 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.03'
     ): CustomerCreditTransferBuilder {
         $this->instance = new CustomerCreditTransfer();
         $now = new DateTime();

--- a/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
@@ -27,6 +27,7 @@ final class CustomerCreditTransferBuilder
     }
 
     /**
+     * @param string $schema has next formula urn:iso:std:iso:20022:tech:xsd:msgName.001.msgNameVersion
      * @param string $debitorFinInstBIC
      * @param string $debitorIBAN
      * @param string $debitorName
@@ -40,6 +41,7 @@ final class CustomerCreditTransferBuilder
      * @return $this
      */
     public function createInstance(
+        string $schema,
         string $debitorFinInstBIC,
         string $debitorIBAN,
         string $debitorName,
@@ -52,7 +54,7 @@ final class CustomerCreditTransferBuilder
         $now = new DateTime();
 
         $xmDocument = $this->instance->createElementNS(
-            'urn:iso:std:iso:20022:tech:xsd:pain.001.001.03',
+            $schema,
             'Document'
         );
         $xmDocument->setAttributeNS(

--- a/src/Builders/CustomerCreditTransfer/CustomerInstantCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerInstantCreditTransferBuilder.php
@@ -28,7 +28,6 @@ final class CustomerInstantCreditTransferBuilder
     }
 
     /**
-     * @param string $schema has next formula urn:iso:std:iso:20022:tech:xsd:msgName.001.msgNameVersion
      * @param string $debtorFinInstBic
      * @param string $debttorIban
      * @param string $debitorName
@@ -36,16 +35,17 @@ final class CustomerInstantCreditTransferBuilder
      * you request your credit institution to book each transaction within this order separately.
      * @param string|null $msgId
      * @param string|null $paymentReference
+     * @param string $schema default namespace schema urn:iso:std:iso:20022:tech:xsd:pain.001.001.03
      * @return CustomerInstantCreditTransferBuilder
      */
     public function createInstance(
-        string $schema,
         string $debtorFinInstBic,
         string $debttorIban,
         string $debitorName,
         bool $batchBooking = true,
         string $msgId = null,
-        string $paymentReference = null
+        string $paymentReference = null,
+        string $schema = 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.03'
     ): CustomerInstantCreditTransferBuilder {
         $this->instance = new CustomerCreditTransfer();
         $now = new DateTime();

--- a/src/Builders/CustomerCreditTransfer/CustomerInstantCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerInstantCreditTransferBuilder.php
@@ -28,6 +28,7 @@ final class CustomerInstantCreditTransferBuilder
     }
 
     /**
+     * @param string $schema has next formula urn:iso:std:iso:20022:tech:xsd:msgName.001.msgNameVersion
      * @param string $debtorFinInstBic
      * @param string $debttorIban
      * @param string $debitorName
@@ -38,6 +39,7 @@ final class CustomerInstantCreditTransferBuilder
      * @return CustomerInstantCreditTransferBuilder
      */
     public function createInstance(
+        string $schema,
         string $debtorFinInstBic,
         string $debttorIban,
         string $debitorName,
@@ -49,7 +51,7 @@ final class CustomerInstantCreditTransferBuilder
         $now = new DateTime();
 
         $xmDocument = $this->instance->createElementNS(
-            'urn:iso:std:iso:20022:tech:xsd:pain.001.001.03',
+            $schema,
             'Document'
         );
         $xmDocument->setAttributeNS(

--- a/src/Builders/CustomerCreditTransfer/CustomerSwissCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerSwissCreditTransferBuilder.php
@@ -33,19 +33,19 @@ final class CustomerSwissCreditTransferBuilder
     }
 
     /**
-     * @param string $schema has next formula urn:iso:std:iso:20022:tech:xsd:msgName.001.msgNameVersion
      * @param string $debitorFinInstBIC
      * @param string $debitorIBAN
      * @param string $debitorName
+     * @param string $schema default namespace schema urn:iso:std:iso:20022:tech:xsd:pain.001.001.03
      *
      * @return $this
      * @throws \DOMException
      */
     public function createInstance(
-        string $schema,
         string $debitorFinInstBIC,
         string $debitorIBAN,
-        string $debitorName
+        string $debitorName,
+        string $schema = 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.03'
     ): CustomerSwissCreditTransferBuilder {
         $this->instance = new CustomerCreditTransfer();
         $now = new DateTime();

--- a/src/Builders/CustomerDirectDebit/CustomerDirectDebitBuilder.php
+++ b/src/Builders/CustomerDirectDebit/CustomerDirectDebitBuilder.php
@@ -27,7 +27,6 @@ final class CustomerDirectDebitBuilder
     }
 
     /**
-     * @param string $schema has next formula urn:iso:std:iso:20022:tech:xsd:msgName.001.msgNameVersion
      * @param string $creditorFinInstBic
      * @param string $creditorIban
      * @param string $creditorName
@@ -40,12 +39,12 @@ final class CustomerDirectDebitBuilder
      * least for 15 days. Used for rejecting duplicated transactions (max length: 35 characters)
      * @param string|null $paymentReference Overwrite default payment reference -
      * visible on creditors bank statement (max length: 35 characters)
+     * @param string $schema default namespace schema urn:iso:std:iso:20022:tech:xsd:pain.008.001.02
      *
      * @return $this
      * @throws \DOMException
      */
     public function createInstance(
-        string $schema,
         string $creditorFinInstBic,
         string $creditorIban,
         string $creditorName,
@@ -54,7 +53,8 @@ final class CustomerDirectDebitBuilder
         DateTime $collectionDate = null,
         bool $batchBooking = true,
         string $msgId = null,
-        string $paymentReference = null
+        string $paymentReference = null,
+        string $schema = 'urn:iso:std:iso:20022:tech:xsd:pain.008.001.02'
     ): CustomerDirectDebitBuilder {
         $this->instance = new CustomerDirectDebit();
         $now = new DateTime();

--- a/src/Factories/DocumentFactory.php
+++ b/src/Factories/DocumentFactory.php
@@ -12,12 +12,13 @@ use AndrewSvirin\Ebics\Models\Document;
  */
 final class DocumentFactory
 {
+    /**
+     * @param string $content requires already UTF-8 encoded content
+     * @return Document
+     */
     public function create(string $content): Document
     {
         $document = new Document();
-
-        $content = mb_convert_encoding($content, 'UTF-8', mb_list_encodings());
-
         $document->loadXML($content);
 
         return $document;

--- a/src/Factories/DocumentFactory.php
+++ b/src/Factories/DocumentFactory.php
@@ -15,7 +15,10 @@ final class DocumentFactory
     public function create(string $content): Document
     {
         $document = new Document();
-        $document->loadXML(utf8_encode($content));
+
+        $content = mb_convert_encoding($content, 'UTF-8', mb_list_encodings());
+
+        $document->loadXML($content);
 
         return $document;
     }


### PR DESCRIPTION
Harmonization of the Document Builder to support custom schema namespaces

# Breaking change
`$schema` attribute added for CCT and CIP (like in CustomerDirectDebitBuilder.php)

This change harmonize all transaction builders to support the schema attribute for all order types as already implemented in SDD

## Additional changes
* Remove deprecated utf8_encode method


