### PR TITLE
Allow custom date range for order type PTK

### DIFF
--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -375,16 +375,21 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws Exceptions\EbicsException
      */
-    public function PTK(DateTimeInterface $dateTime = null): DownloadOrderResult
-    {
+    public function PTK(
+        DateTimeInterface $startDate = null,
+        DateTimeInterface $stopDate = null,
+        DateTimeInterface $dateTime = null
+    ): DownloadOrderResult {
         if (null === $dateTime) {
             $dateTime = new DateTime();
         }
 
         $transaction = $this->downloadTransaction(
-            function ($segmentNumber, $isLastSegment) use ($dateTime) {
+            function ($segmentNumber, $isLastSegment) use ($startDate, $stopDate, $dateTime) {
                 return $this->requestFactory->createPTK(
                     $dateTime,
+                    $startDate,
+                    $stopDate,
                     $segmentNumber,
                     $isLastSegment
                 );

--- a/src/Factories/RequestFactory.php
+++ b/src/Factories/RequestFactory.php
@@ -386,6 +386,8 @@ abstract class RequestFactory
      */
     public function createPTK(
         DateTimeInterface $dateTime,
+        DateTimeInterface $startDate = null,
+        DateTimeInterface $stopDate = null,
         int $segmentNumber = null,
         bool $isLastSegment = null
     ): Request {
@@ -399,9 +401,9 @@ abstract class RequestFactory
 
         $request = $this
             ->createRequestBuilderInstance()
-            ->addContainerSecured(function (XmlBuilder $builder) use ($context) {
-                $builder->addHeader(function (HeaderBuilder $builder) use ($context) {
-                    $builder->addStatic(function (StaticBuilder $builder) use ($context) {
+            ->addContainerSecured(function (XmlBuilder $builder) use ($context, $startDate, $stopDate) {
+                $builder->addHeader(function (HeaderBuilder $builder) use ($context, $startDate, $stopDate) {
+                    $builder->addStatic(function (StaticBuilder $builder) use ($context, $startDate, $stopDate) {
                         $builder
                             ->addHostId($context->getBank()->getHostId())
                             ->addRandomNonce()
@@ -409,10 +411,13 @@ abstract class RequestFactory
                             ->addPartnerId($context->getUser()->getPartnerId())
                             ->addUserId($context->getUser()->getUserId())
                             ->addProduct('Ebics client PHP', 'de')
-                            ->addOrderDetails(function (OrderDetailsBuilder $orderDetailsBuilder) {
+                            ->addOrderDetails(function (OrderDetailsBuilder $orderDetailsBuilder) use (
+                                $startDate,
+                                $stopDate
+                            ) {
                                 $this
                                     ->addOrderType($orderDetailsBuilder, 'PTK')
-                                    ->addStandardOrderParams();
+                                    ->addStandardOrderParams($startDate, $stopDate);
                             })
                             ->addBankPubKeyDigests(
                                 $context->getKeyring()->getBankSignatureXVersion(),


### PR DESCRIPTION
Sometimes its necessary to fetch older logs which may already fetched in a previous request. With this improvement the PTK order type supports custom date ranges.

Examples:
```php
// Default: Fetch logs since last fetch
$ptk = $this->client->PTK();

// Fetch logs from -3 hours to now
$ptk = $this->client->PTK(Carbon::now()->subHours(3));

// Fetch logs from -24 hours to -12 hours
$ptk = $this->client->PTK(Carbon::now()->subHours(24), Carbon::now()->subHours(12));

// Fetch logs from yesterday
$ptk = $this->client->PTK(Carbon::now()->subDay()->startOfDay(), Carbon::now()->subDay()->endOfDay());

return $ptk->getData();
```

