### PR TITLE
Fix support for direct debit transactions for business (CDB)

### DIFF
--- a/src/Builders/CustomerDirectDebit/CustomerDirectDebitBuilder.php
+++ b/src/Builders/CustomerDirectDebit/CustomerDirectDebitBuilder.php
@@ -40,6 +40,7 @@ final class CustomerDirectDebitBuilder
      * least for 15 days. Used for rejecting duplicated transactions (max length: 35 characters)
      * @param string|null $paymentReference Overwrite default payment reference -
      * visible on creditors bank statement (max length: 35 characters)
+     * @param string $localInstrument Define whether the payment in question is Core or B2B: (CORE | B2B)
      * @return $this
      * @throws \DOMException
      */
@@ -53,7 +54,8 @@ final class CustomerDirectDebitBuilder
         DateTime $collectionDate = null,
         bool $batchBooking = true,
         string $msgId = null,
-        string $paymentReference = null
+        string $paymentReference = null,
+        string $localInstrument = 'CORE'
     ): CustomerDirectDebitBuilder {
         $this->instance = new CustomerDirectDebit();
         $now = new DateTime();
@@ -143,7 +145,7 @@ final class CustomerDirectDebitBuilder
         $xmlPmtTpInf->appendChild($xmlLclInstrm);
 
         $xmlCd = $this->instance->createElement('Cd');
-        $xmlCd->nodeValue = 'CORE';
+        $xmlCd->nodeValue = $localInstrument;
         $xmlLclInstrm->appendChild($xmlCd);
 
         $xmlSeqTp = $this->instance->createElement('SeqTp');


### PR DESCRIPTION
This PR is referring to a previous integration of direct debit transactions for business (CDB): https://github.com/andrew-svirin/ebics-client-php/pull/194

To perform direct debit transactions with the business type, we need also a way to adjust the `localInstrument` Node in our request. Source: https://knowledge.xmldation.com/support/epc/lclinstrm

Standard: `CORE`
Business: `B2B`

This PR will add a method parameter to the CustomerDirectDebitBuilder (default is `CORE` like before) which will allow to change the `localInstrument` parameter.