### PR TITLE
Add methode to define an offset on OrderId

### DIFF
--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -1436,4 +1436,14 @@ final class EbicsClient implements EbicsClientInterface
 
         $this->keyring->setPassword($newPassword);
     }
+
+    public function setOrderIdOffset(int $offset): void
+    {
+        $this->requestFactory->setOrderIdOffset($offset);
+    }
+
+    public function getOrderIdOffset(): int
+    {
+        return $this->requestFactory->getOrderIdOffset();
+    }
 }

--- a/src/Factories/RequestFactory.php
+++ b/src/Factories/RequestFactory.php
@@ -49,6 +49,8 @@ abstract class RequestFactory
     protected UserSignatureHandler $userSignatureHandler;
     protected CryptService $cryptService;
     protected ZipService $zipService;
+    protected int $orderIdOffset = 0;
+
 
     public function __construct(
         Bank $bank,
@@ -1018,6 +1020,16 @@ abstract class RequestFactory
         }
 
         return $requestContext;
+    }
+
+    public function setOrderIdOffset(int $orderIdOffset): void
+    {
+        $this->orderIdOffset = $orderIdOffset;
+    }
+
+    public function getOrderIdOffset(): int
+    {
+        return $this->orderIdOffset;
     }
 
     abstract public function prepareDownloadContext(RequestContext $requestContext = null): RequestContext;

--- a/src/Factories/RequestFactoryV24.php
+++ b/src/Factories/RequestFactoryV24.php
@@ -44,7 +44,7 @@ final class RequestFactoryV24 extends RequestFactoryV2
                 $orderAttribute = OrderDetailsBuilder::ORDER_ATTRIBUTE_DZHNN;
         }
 
-        $orderId = $this->cryptService->generateOrderId($this->user->getPartnerId());
+        $orderId = $this->cryptService->generateOrderId($this->user->getPartnerId(), $this->getOrderIdOffset());
 
         return $orderDetailsBuilder
             ->addOrderType($orderType)

--- a/src/Services/CryptService.php
+++ b/src/Services/CryptService.php
@@ -493,7 +493,7 @@ final class CryptService
                 continue;
             }
 
-            $chrCode = ($dec + $offset) % $letDecRng;
+            $chrCode = $dec % $letDecRng;
 
             if ($chrCode > $letRng) {
                 $chrs[] = $chrCode - $letRng;

--- a/src/Services/CryptService.php
+++ b/src/Services/CryptService.php
@@ -450,16 +450,29 @@ final class CryptService
     }
 
     /**
-     * Generate order id from A000 to ZZZZ
+     * Generate order id from A000 to ZZZZ with offset.
      * Unique value per partner for customer.
      *
      * @param string $partnerId
+     * @param int $offset
      *
      * @return string
      */
-    public function generateOrderId(string $partnerId): string
+    public function generateOrderId(string $partnerId, int $offset = 0): string
     {
         $hash = $this->hash($partnerId, 'crc32', false);
+
+        $hashToDesc = hexdec($hash);
+
+        $hasDeschWithOffset = $hashToDesc + $offset;
+
+        if ($hasDeschWithOffset > 0xffffffff) {
+            $hasDeschWithOffset = $hasDeschWithOffset - 0xffffffff;
+        }
+
+        $hash = dechex($hasDeschWithOffset);
+
+        $hash = str_pad($hash, 8, '0', STR_PAD_LEFT);
 
         $decs = str_split($hash, 2);
 
@@ -480,7 +493,7 @@ final class CryptService
                 continue;
             }
 
-            $chrCode = $dec % $letDecRng;
+            $chrCode = ($dec + $offset) % $letDecRng;
 
             if ($chrCode > $letRng) {
                 $chrs[] = $chrCode - $letRng;


### PR DESCRIPTION
Add possibility to set an offset on orderId from EbicsClient Object.

To be used for certain banks that require the orderId to be incremented to get around an erroneous initialization call.