### PR TITLE
PHP 8.4 Support: Explicitly marked property and parameter types as nullable

### DIFF
--- a/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerCreditTransferBuilder.php
@@ -53,10 +53,10 @@ final class CustomerCreditTransferBuilder
         string $debitorFinInstBIC,
         string $debitorIBAN,
         string $debitorName,
-        DateTime $executionDate = null,
+        ?DateTime $executionDate = null,
         bool $batchBooking = true,
-        string $msgId = null,
-        string $paymentReference = null
+        ?string $msgId = null,
+        ?string $paymentReference = null
     ): CustomerCreditTransferBuilder {
         $this->instance = new CustomerCreditTransfer();
         $now = new DateTime();
@@ -191,8 +191,8 @@ final class CustomerCreditTransferBuilder
 
     private function createCreditTransferTransactionElement(
         float $amount,
-        string $instrId = null,
-        string $endToEndId = null
+        ?string $instrId = null,
+        ?string $endToEndId = null
     ): DOMElement {
         $xpath = $this->prepareXPath($this->instance);
         $nbOfTxsList = $xpath->query('//CstmrCdtTrfInitn//GrpHdr/NbOfTxs');
@@ -257,7 +257,7 @@ final class CustomerCreditTransferBuilder
         string $creditorIBAN,
         string $creditorName,
         ?PostalAddressInterface $postalAddress,
-        string $purpose = null
+        ?string $purpose = null
     ): void {
         //agent
         if ($creditorFinInstBIC !== null) {
@@ -312,7 +312,7 @@ final class CustomerCreditTransferBuilder
         ?PostalAddressInterface $postalAddress,
         float $amount,
         string $currency,
-        string $purpose = null
+        ?string $purpose = null
     ): CustomerCreditTransferBuilder {
         if ($currency !== 'EUR') {
             throw new InvalidArgumentException('The SEPA transaction is restricted to EUR currency.');
@@ -334,7 +334,7 @@ final class CustomerCreditTransferBuilder
         ?PostalAddressInterface $postalAddress,
         float $amount,
         string $currency,
-        string $purpose = null
+        ?string $purpose = null
     ): CustomerCreditTransferBuilder {
         if ($currency !== 'EUR') {
             throw new InvalidArgumentException('The SEPA transaction is restricted to EUR currency.');
@@ -378,7 +378,7 @@ final class CustomerCreditTransferBuilder
         ?PostalAddressInterface $postalAddress,
         float $amount,
         string $currency,
-        string $purpose = null
+        ?string $purpose = null
     ): CustomerCreditTransferBuilder {
         $xmlCdtTrfTxInf = $this->createCreditTransferTransactionElement($amount);
 

--- a/src/Builders/CustomerCreditTransfer/CustomerInstantCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerInstantCreditTransferBuilder.php
@@ -44,8 +44,8 @@ final class CustomerInstantCreditTransferBuilder
         string $debttorIban,
         string $debitorName,
         bool $batchBooking = true,
-        string $msgId = null,
-        string $paymentReference = null
+        ?string $msgId = null,
+        ?string $paymentReference = null
     ): CustomerInstantCreditTransferBuilder {
         $this->instance = new CustomerCreditTransfer();
         $now = new DateTime();
@@ -197,8 +197,8 @@ final class CustomerInstantCreditTransferBuilder
         float $amount,
         string $currency,
         string $purpose,
-        string $endToEndId = null,
-        string $purposeCode = null
+        ?string $endToEndId = null,
+        ?string $purposeCode = null
     ): CustomerInstantCreditTransferBuilder {
         $xpath = $this->prepareXPath($this->instance);
         $nbOfTxsList = $xpath->query('//CstmrCdtTrfInitn/PmtInf/NbOfTxs');

--- a/src/Builders/CustomerCreditTransfer/CustomerSwissCreditTransferBuilder.php
+++ b/src/Builders/CustomerCreditTransfer/CustomerSwissCreditTransferBuilder.php
@@ -195,7 +195,7 @@ final class CustomerSwissCreditTransferBuilder
         string $creditorIBAN,
         string $creditorName,
         ?PostalAddressInterface $postalAddress,
-        string $purpose = null
+        ?string $purpose = null
     ): void {
         //agent
         if ($creditorFinInstBIC !== null) {
@@ -250,7 +250,7 @@ final class CustomerSwissCreditTransferBuilder
         ?PostalAddressInterface $postalAddress,
         float $amount,
         string $currency,
-        string $purpose = null
+        ?string $purpose = null
     ): CustomerSwissCreditTransferBuilder {
         if (!in_array($currency, ['CHF', 'EUR'], true)) {
             throw new InvalidArgumentException('The SEPA transaction is restricted to CHF and EUR currency.');
@@ -274,7 +274,7 @@ final class CustomerSwissCreditTransferBuilder
         ?PostalAddressInterface $postalAddress,
         float $amount,
         string $currency,
-        string $purpose = null
+        ?string $purpose = null
     ): CustomerSwissCreditTransferBuilder {
         if ($currency !== 'EUR') {
             throw new InvalidArgumentException('The SEPA transaction is restricted to EUR currency.');
@@ -321,7 +321,7 @@ final class CustomerSwissCreditTransferBuilder
         ?PostalAddressInterface $postalAddress,
         float $amount,
         string $currency,
-        string $purpose = null
+        ?string $purpose = null
     ): CustomerSwissCreditTransferBuilder {
         $xmlCdtTrfTxInf = $this->createCreditTransferTransactionElement($amount);
 

--- a/src/Builders/CustomerDirectDebit/CustomerDirectDebitBuilder.php
+++ b/src/Builders/CustomerDirectDebit/CustomerDirectDebitBuilder.php
@@ -49,12 +49,12 @@ final class CustomerDirectDebitBuilder
         string $creditorFinInstBic,
         string $creditorIban,
         string $creditorName,
-        string $creditorId = null,
+        ?string $creditorId = null,
         string $sequenceType = 'FRST',
-        DateTime $collectionDate = null,
+        ?DateTime $collectionDate = null,
         bool $batchBooking = true,
-        string $msgId = null,
-        string $paymentReference = null,
+        ?string $msgId = null,
+        ?string $paymentReference = null,
         string $localInstrument = 'CORE'
     ): CustomerDirectDebitBuilder {
         $this->instance = new CustomerDirectDebit();
@@ -227,8 +227,8 @@ final class CustomerDirectDebitBuilder
         string $currency,
         string $purpose,
         string $mandateReference = '1',
-        DateTime $signatureDate = null,
-        string $endToEndId = null
+        ?DateTime $signatureDate = null,
+        ?string $endToEndId = null
     ): CustomerDirectDebitBuilder {
         $xpath = $this->prepareXPath($this->instance);
         $nbOfTxsList = $xpath->query('//CstmrDrctDbtInitn/PmtInf/NbOfTxs');

--- a/src/Builders/Request/DataTransferBuilder.php
+++ b/src/Builders/Request/DataTransferBuilder.php
@@ -36,7 +36,7 @@ abstract class DataTransferBuilder
         return $this;
     }
 
-    public function addOrderData(string $orderData = null, string $transactionKey = null): DataTransferBuilder
+    public function addOrderData(?string $orderData = null, ?string $transactionKey = null): DataTransferBuilder
     {
         $xmlDataTransfer = $this->dom->createElement('OrderData');
         $this->instance->appendChild($xmlDataTransfer);
@@ -60,7 +60,7 @@ abstract class DataTransferBuilder
         return $this;
     }
 
-    public function addDataEncryptionInfo(Closure $callable = null): DataTransferBuilder
+    public function addDataEncryptionInfo(?Closure $callable = null): DataTransferBuilder
     {
         $dataEncryptionInfoBuilder = new DataEncryptionInfoBuilder($this->cryptService, $this->dom);
         $this->instance->appendChild($dataEncryptionInfoBuilder->createInstance()->getInstance());
@@ -87,7 +87,7 @@ abstract class DataTransferBuilder
         return $this;
     }
 
-    abstract public function addDataDigest(string $signatureVersion, string $digest = null): DataTransferBuilder;
+    abstract public function addDataDigest(string $signatureVersion, ?string $digest = null): DataTransferBuilder;
 
     abstract public function addAdditionalOrderInfo(): DataTransferBuilder;
 

--- a/src/Builders/Request/DataTransferBuilderV2.php
+++ b/src/Builders/Request/DataTransferBuilderV2.php
@@ -10,7 +10,7 @@ namespace EbicsApi\Ebics\Builders\Request;
  */
 final class DataTransferBuilderV2 extends DataTransferBuilder
 {
-    public function addDataDigest(string $signatureVersion, string $digest = null): DataTransferBuilder
+    public function addDataDigest(string $signatureVersion, ?string $digest = null): DataTransferBuilder
     {
         // Skipped.
         return $this;

--- a/src/Builders/Request/DataTransferBuilderV3.php
+++ b/src/Builders/Request/DataTransferBuilderV3.php
@@ -10,7 +10,7 @@ namespace EbicsApi\Ebics\Builders\Request;
  */
 final class DataTransferBuilderV3 extends DataTransferBuilder
 {
-    public function addDataDigest(string $signatureVersion, string $digest = null): DataTransferBuilder
+    public function addDataDigest(string $signatureVersion, ?string $digest = null): DataTransferBuilder
     {
         $xmlDataDigest = $this->dom->createElement('DataDigest');
         $xmlDataDigest->setAttribute('SignatureVersion', $signatureVersion);

--- a/src/Builders/Request/HeaderBuilder.php
+++ b/src/Builders/Request/HeaderBuilder.php
@@ -40,7 +40,7 @@ abstract class HeaderBuilder
 
     abstract public function addStatic(Closure $callback): HeaderBuilder;
 
-    public function addMutable(Closure $callable = null): HeaderBuilder
+    public function addMutable(?Closure $callable = null): HeaderBuilder
     {
         $mutableBuilder = new MutableBuilder($this->dom);
         $this->instance->appendChild($mutableBuilder->createInstance()->getInstance());

--- a/src/Builders/Request/MutableBuilder.php
+++ b/src/Builders/Request/MutableBuilder.php
@@ -47,7 +47,7 @@ final class MutableBuilder
         return $this;
     }
 
-    public function addSegmentNumber(int $segmentNumber = null, ?bool $isLastSegment = null): MutableBuilder
+    public function addSegmentNumber(?int $segmentNumber = null, ?bool $isLastSegment = null): MutableBuilder
     {
         if (null !== $segmentNumber) {
             $xmlSegmentNumber = $this->dom->createElement('SegmentNumber');

--- a/src/Builders/Request/OrderDetailsBuilder.php
+++ b/src/Builders/Request/OrderDetailsBuilder.php
@@ -62,8 +62,8 @@ abstract class OrderDetailsBuilder
     abstract public function addOrderAttribute(string $orderAttribute): OrderDetailsBuilder;
 
     public function addStandardOrderParams(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null
     ): OrderDetailsBuilder {
         // Add StandardOrderParams to OrderDetails.
         $xmlStandardOrderParams = $this->dom->createElement('StandardOrderParams');

--- a/src/Builders/Request/StaticBuilder.php
+++ b/src/Builders/Request/StaticBuilder.php
@@ -99,7 +99,7 @@ abstract class StaticBuilder
         return $this;
     }
 
-    abstract public function addOrderDetails(Closure $callable = null): StaticBuilder;
+    abstract public function addOrderDetails(?Closure $callable = null): StaticBuilder;
 
     public function addNumSegments(int $numSegments): StaticBuilder
     {

--- a/src/Builders/Request/StaticBuilderV2.php
+++ b/src/Builders/Request/StaticBuilderV2.php
@@ -12,7 +12,7 @@ use Closure;
  */
 final class StaticBuilderV2 extends StaticBuilder
 {
-    public function addOrderDetails(Closure $callable = null): StaticBuilder
+    public function addOrderDetails(?Closure $callable = null): StaticBuilder
     {
         $orderDetailsBuilder = new OrderDetailsBuilderV2($this->dom);
         $this->instance->appendChild($orderDetailsBuilder->createInstance()->getInstance());

--- a/src/Builders/Request/StaticBuilderV3.php
+++ b/src/Builders/Request/StaticBuilderV3.php
@@ -12,7 +12,7 @@ use Closure;
  */
 final class StaticBuilderV3 extends StaticBuilder
 {
-    public function addOrderDetails(Closure $callable = null): StaticBuilder
+    public function addOrderDetails(?Closure $callable = null): StaticBuilder
     {
         $orderDetailsBuilder = new OrderDetailsBuilderV3($this->dom);
         $this->instance->appendChild($orderDetailsBuilder->createInstance()->getInstance());

--- a/src/Builders/Request/XmlBuilder.php
+++ b/src/Builders/Request/XmlBuilder.php
@@ -93,7 +93,7 @@ abstract class XmlBuilder
 
     abstract public function addHeader(Closure $callback): XmlBuilder;
 
-    abstract public function addBody(Closure $callback = null): XmlBuilder;
+    abstract public function addBody(?Closure $callback = null): XmlBuilder;
 
     public function addHostId(string $hostId): XmlBuilder
     {

--- a/src/Builders/Request/XmlBuilderV24.php
+++ b/src/Builders/Request/XmlBuilderV24.php
@@ -26,7 +26,7 @@ final class XmlBuilderV24 extends XmlBuilder
         return $this;
     }
 
-    public function addBody(Closure $callback = null): XmlBuilder
+    public function addBody(?Closure $callback = null): XmlBuilder
     {
         $bodyBuilder = new BodyBuilderV2($this->zipService, $this->cryptService, $this->dom);
         $body = $bodyBuilder->createInstance()->getInstance();

--- a/src/Builders/Request/XmlBuilderV25.php
+++ b/src/Builders/Request/XmlBuilderV25.php
@@ -26,7 +26,7 @@ final class XmlBuilderV25 extends XmlBuilder
         return $this;
     }
 
-    public function addBody(Closure $callback = null): XmlBuilder
+    public function addBody(?Closure $callback = null): XmlBuilder
     {
         $bodyBuilder = new BodyBuilderV2($this->zipService, $this->cryptService, $this->dom);
         $body = $bodyBuilder->createInstance()->getInstance();

--- a/src/Builders/Request/XmlBuilderV30.php
+++ b/src/Builders/Request/XmlBuilderV30.php
@@ -26,7 +26,7 @@ final class XmlBuilderV30 extends XmlBuilder
         return $this;
     }
 
-    public function addBody(Closure $callback = null): XmlBuilder
+    public function addBody(?Closure $callback = null): XmlBuilder
     {
         $bodyBuilder = new BodyBuilderV3($this->zipService, $this->cryptService, $this->dom);
         $body = $bodyBuilder->createInstance()->getInstance();

--- a/src/Contracts/Crypt/X509Interface.php
+++ b/src/Contracts/Crypt/X509Interface.php
@@ -87,7 +87,7 @@ interface X509Interface
         $value,
         bool $critical = false,
         bool $replace = true,
-        string $path = null
+        ?string $path = null
     );
 
     /**
@@ -216,5 +216,5 @@ interface X509Interface
      *
      * @return mixed
      */
-    public function getAttribute(string $id, int $disposition = X509::ATTR_ALL, array $csr = null);
+    public function getAttribute(string $id, int $disposition = X509::ATTR_ALL, ?array $csr = null);
 }

--- a/src/Contracts/EbicsClientInterface.php
+++ b/src/Contracts/EbicsClientInterface.php
@@ -38,7 +38,7 @@ interface EbicsClientInterface
      * @param array|null $options Setup to specify custom certificate, private_key and version
      * for Electronic Signature, Authorization and Identification, Encryption details.
      */
-    public function createUserSignatures(array $options = null): void;
+    public function createUserSignatures(?array $options = null): void;
 
     /**
      * Download supported protocol versions for the Bank.
@@ -55,7 +55,7 @@ interface EbicsClientInterface
      *
      * @return Response
      */
-    public function INI(RequestContext $context = null): Response;
+    public function INI(?RequestContext $context = null): Response;
 
     /**
      * Make HIA request.
@@ -65,7 +65,7 @@ interface EbicsClientInterface
      *
      * @return Response
      */
-    public function HIA(RequestContext $context = null): Response;
+    public function HIA(?RequestContext $context = null): Response;
 
     /**
      * Make H3K request.
@@ -75,7 +75,7 @@ interface EbicsClientInterface
      *
      * @return Response
      */
-    public function H3K(RequestContext $context = null): Response;
+    public function H3K(?RequestContext $context = null): Response;
 
     /**
      * Download the Bank public signatures authentication (X002) and encryption (E002).
@@ -85,7 +85,7 @@ interface EbicsClientInterface
      *
      * @return InitializationOrderResult
      */
-    public function HPB(RequestContext $context = null): InitializationOrderResult;
+    public function HPB(?RequestContext $context = null): InitializationOrderResult;
 
     /**
      * Suspend activated Keyring.
@@ -94,7 +94,7 @@ interface EbicsClientInterface
      *
      * @return UploadOrderResult
      */
-    public function SPR(RequestContext $context = null): UploadOrderResult;
+    public function SPR(?RequestContext $context = null): UploadOrderResult;
 
     /**
      * Download the bank server parameters.
@@ -103,7 +103,7 @@ interface EbicsClientInterface
      *
      * @return DownloadOrderResult
      */
-    public function HPD(RequestContext $context = null): DownloadOrderResult;
+    public function HPD(?RequestContext $context = null): DownloadOrderResult;
 
     /**
      * Download customer's customer and subscriber information.
@@ -112,7 +112,7 @@ interface EbicsClientInterface
      *
      * @return DownloadOrderResult
      */
-    public function HKD(RequestContext $context = null): DownloadOrderResult;
+    public function HKD(?RequestContext $context = null): DownloadOrderResult;
 
     /**
      * Download subscriber's customer and subscriber information.
@@ -121,7 +121,7 @@ interface EbicsClientInterface
      *
      * @return DownloadOrderResult
      */
-    public function HTD(RequestContext $context = null): DownloadOrderResult;
+    public function HTD(?RequestContext $context = null): DownloadOrderResult;
 
     /**
      * Download Bank available order types.
@@ -130,7 +130,7 @@ interface EbicsClientInterface
      *
      * @return DownloadOrderResult
      */
-    public function HAA(RequestContext $context = null): DownloadOrderResult;
+    public function HAA(?RequestContext $context = null): DownloadOrderResult;
 
     /**
      * Download transaction status.
@@ -142,9 +142,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function PTK(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -157,9 +157,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function VMK(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -172,9 +172,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function STA(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -187,9 +187,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function BKA(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -202,9 +202,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function C52(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -217,9 +217,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function C53(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -232,9 +232,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function C54(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -247,9 +247,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function Z52(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -262,9 +262,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function Z53(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -277,9 +277,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function Z54(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -292,9 +292,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function ZSR(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -307,9 +307,9 @@ interface EbicsClientInterface
      * @return DownloadOrderResult
      */
     public function XEK(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -324,9 +324,9 @@ interface EbicsClientInterface
      */
     public function BTD(
         BTDContext $btdContext,
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -341,7 +341,7 @@ interface EbicsClientInterface
     public function BTU(
         BTUContext $btuContext,
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult;
 
     /**
@@ -356,9 +356,9 @@ interface EbicsClientInterface
      */
     public function FDL(
         FDLContext $fdlContext,
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult;
 
     /**
@@ -374,7 +374,7 @@ interface EbicsClientInterface
     public function FUL(
         FULContext $fulContext,
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult;
 
     /**
@@ -389,7 +389,7 @@ interface EbicsClientInterface
      *
      * @return UploadOrderResult
      */
-    public function CCT(OrderDataInterface $orderData, RequestContext $context = null): UploadOrderResult;
+    public function CCT(OrderDataInterface $orderData, ?RequestContext $context = null): UploadOrderResult;
 
     /**
      * Upload initiation of the direct debit transaction.
@@ -402,7 +402,7 @@ interface EbicsClientInterface
      *
      * @return UploadOrderResult
      */
-    public function CDD(OrderDataInterface $orderData, RequestContext $context = null): UploadOrderResult;
+    public function CDD(OrderDataInterface $orderData, ?RequestContext $context = null): UploadOrderResult;
 
     /**
      * Upload initiation of the direct debit transaction for business.
@@ -415,7 +415,7 @@ interface EbicsClientInterface
      *
      * @return UploadOrderResult
      */
-    public function CDB(OrderDataInterface $orderData, RequestContext $context = null): UploadOrderResult;
+    public function CDB(OrderDataInterface $orderData, ?RequestContext $context = null): UploadOrderResult;
 
     /**
      * Upload initiation of the instant credit transfer per SEPA.
@@ -425,7 +425,7 @@ interface EbicsClientInterface
      *
      * @return UploadOrderResult
      */
-    public function CIP(OrderDataInterface $orderData, RequestContext $context = null): UploadOrderResult;
+    public function CIP(OrderDataInterface $orderData, ?RequestContext $context = null): UploadOrderResult;
 
     /**
      * Upload initiation credit transfer per Swiss Payments specification set by Six banking services.
@@ -438,7 +438,7 @@ interface EbicsClientInterface
      *
      * @return UploadOrderResult
      */
-    public function XE2(OrderDataInterface $orderData, RequestContext $context = null): UploadOrderResult;
+    public function XE2(OrderDataInterface $orderData, ?RequestContext $context = null): UploadOrderResult;
 
     /**
      * Upload SEPA Direct Debit Initiation, CH definitions, CORE.
@@ -450,7 +450,7 @@ interface EbicsClientInterface
      *
      * @return UploadOrderResult
      */
-    public function XE3(OrderDataInterface $orderData, RequestContext $context = null): UploadOrderResult;
+    public function XE3(OrderDataInterface $orderData, ?RequestContext $context = null): UploadOrderResult;
 
     /**
      * Upload Credit transfer CGI (SEPA & non SEPA).
@@ -461,7 +461,7 @@ interface EbicsClientInterface
      *
      * @return UploadOrderResult
      */
-    public function YCT(OrderDataInterface $orderData, RequestContext $context = null): UploadOrderResult;
+    public function YCT(OrderDataInterface $orderData, ?RequestContext $context = null): UploadOrderResult;
 
     /**
      * Download List the orders for which the user is authorized as a signatory.
@@ -470,7 +470,7 @@ interface EbicsClientInterface
      *
      * @return DownloadOrderResult
      */
-    public function HVU(RequestContext $context = null): DownloadOrderResult;
+    public function HVU(?RequestContext $context = null): DownloadOrderResult;
 
     /**
      * Download VEU overview with additional information.
@@ -479,7 +479,7 @@ interface EbicsClientInterface
      *
      * @return DownloadOrderResult
      */
-    public function HVZ(RequestContext $context = null): DownloadOrderResult;
+    public function HVZ(?RequestContext $context = null): DownloadOrderResult;
 
     /**
      * Add a VEU signature for order.
@@ -489,7 +489,7 @@ interface EbicsClientInterface
      *
      * @return UploadOrderResult
      */
-    public function HVE(HVEContext $hveContext, RequestContext $context = null): UploadOrderResult;
+    public function HVE(HVEContext $hveContext, ?RequestContext $context = null): UploadOrderResult;
 
     /**
      * Download the state of a VEU order.
@@ -499,7 +499,7 @@ interface EbicsClientInterface
      *
      * @return DownloadOrderResult
      */
-    public function HVD(HVDContext $hvdContext, RequestContext $context = null): DownloadOrderResult;
+    public function HVD(HVDContext $hvdContext, ?RequestContext $context = null): DownloadOrderResult;
 
     /**
      * Download detailed information about an order from VEU processing for which the user is authorized as a signatory.
@@ -509,7 +509,7 @@ interface EbicsClientInterface
      *
      * @return DownloadOrderResult
      */
-    public function HVT(HVTContext $hvtContext, RequestContext $context = null): DownloadOrderResult;
+    public function HVT(HVTContext $hvtContext, ?RequestContext $context = null): DownloadOrderResult;
 
     /**
      * Get Keyring.

--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -150,7 +150,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws EbicsException
      */
-    public function createUserSignatures(array $options = null): void
+    public function createUserSignatures(?array $options = null): void
     {
         $signatureA = $this->createUserSignature(SignatureInterface::TYPE_A, $options['a_details'] ?? null);
         $this->keyring->setUserSignatureAVersion($options['a_version'] ?? SignatureInterface::A_VERSION6);
@@ -182,7 +182,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws EbicsException
      */
-    public function INI(RequestContext $context = null): Response
+    public function INI(?RequestContext $context = null): Response
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $signatureA = $this->getUserSignature(SignatureInterface::TYPE_A);
@@ -200,7 +200,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws EbicsException
      */
-    public function HIA(RequestContext $context = null): Response
+    public function HIA(?RequestContext $context = null): Response
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $signatureE = $this->getUserSignature(SignatureInterface::TYPE_E);
@@ -220,7 +220,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws EbicsException
      */
-    public function H3K(RequestContext $context = null): Response
+    public function H3K(?RequestContext $context = null): Response
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $signatureA = $this->getUserSignature(SignatureInterface::TYPE_A);
@@ -242,7 +242,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws Exceptions\EbicsException
      */
-    public function HPB(RequestContext $context = null): InitializationOrderResult
+    public function HPB(?RequestContext $context = null): InitializationOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $transaction = $this->initializeTransaction(
@@ -265,7 +265,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws Exceptions\EbicsException
      */
-    public function SPR(RequestContext $context = null): UploadOrderResult
+    public function SPR(?RequestContext $context = null): UploadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $context->setOnlyES(true);
@@ -287,7 +287,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws Exceptions\EbicsException
      */
-    public function HPD(RequestContext $context = null): DownloadOrderResult
+    public function HPD(?RequestContext $context = null): DownloadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $transaction = $this->downloadTransaction(
@@ -303,7 +303,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws Exceptions\EbicsException
      */
-    public function HKD(RequestContext $context = null): DownloadOrderResult
+    public function HKD(?RequestContext $context = null): DownloadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $transaction = $this->downloadTransaction(
@@ -319,7 +319,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws Exceptions\EbicsException
      */
-    public function HTD(RequestContext $context = null): DownloadOrderResult
+    public function HTD(?RequestContext $context = null): DownloadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $transaction = $this->downloadTransaction(
@@ -335,7 +335,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws Exceptions\EbicsException
      */
-    public function HAA(RequestContext $context = null): DownloadOrderResult
+    public function HAA(?RequestContext $context = null): DownloadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $transaction = $this->downloadTransaction(
@@ -352,9 +352,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function PTK(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -373,9 +373,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function VMK(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -395,9 +395,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function STA(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -417,9 +417,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function BKA(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -439,9 +439,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function C52(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -461,9 +461,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function C53(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -483,9 +483,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function C54(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -505,9 +505,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function Z52(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -527,9 +527,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function Z53(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -549,9 +549,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function Z54(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -571,9 +571,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function ZSR(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -593,9 +593,9 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsException
      */
     public function XEK(
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareDownloadContext($context)
             ->setStartDateTime($startDateTime)
@@ -616,9 +616,9 @@ final class EbicsClient implements EbicsClientInterface
      */
     public function BTD(
         BTDContext $btdContext,
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareStandardContext($context)
             ->setBTDContext($btdContext)
@@ -641,7 +641,7 @@ final class EbicsClient implements EbicsClientInterface
     public function BTU(
         BTUContext $btuContext,
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult {
         $context = $this->requestFactory->prepareStandardContext($context)
             ->setBTUContext($btuContext);
@@ -665,9 +665,9 @@ final class EbicsClient implements EbicsClientInterface
      */
     public function FDL(
         FDLContext $fdlContext,
-        DateTimeInterface $startDateTime = null,
-        DateTimeInterface $endDateTime = null,
-        RequestContext $context = null
+        ?DateTimeInterface $startDateTime = null,
+        ?DateTimeInterface $endDateTime = null,
+        ?RequestContext $context = null
     ): DownloadOrderResult {
         $context = $this->requestFactory->prepareStandardContext($context)
             ->setFdlContext($fdlContext)
@@ -691,7 +691,7 @@ final class EbicsClient implements EbicsClientInterface
     public function FUL(
         FULContext $fulContext,
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult {
         $context = $this->requestFactory->prepareStandardContext($context)
             ->setFulContext($fulContext);
@@ -716,7 +716,7 @@ final class EbicsClient implements EbicsClientInterface
      */
     public function CCT(
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult {
         $context = $this->requestFactory->prepareUploadContext($context);
         $transaction = $this->uploadTransaction(
@@ -739,7 +739,7 @@ final class EbicsClient implements EbicsClientInterface
      */
     public function CDD(
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult {
         $context = $this->requestFactory->prepareUploadContext($context);
         $transaction = $this->uploadTransaction(
@@ -762,7 +762,7 @@ final class EbicsClient implements EbicsClientInterface
      */
     public function CDB(
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult {
         $context = $this->requestFactory->prepareUploadContext($context);
         $transaction = $this->uploadTransaction(
@@ -785,7 +785,7 @@ final class EbicsClient implements EbicsClientInterface
      */
     public function CIP(
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult {
         $context = $this->requestFactory->prepareUploadContext($context);
         $transaction = $this->uploadTransaction(
@@ -808,7 +808,7 @@ final class EbicsClient implements EbicsClientInterface
      */
     public function XE2(
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult {
         $context = $this->requestFactory->prepareUploadContext($context);
         $transaction = $this->uploadTransaction(
@@ -831,7 +831,7 @@ final class EbicsClient implements EbicsClientInterface
      */
     public function XE3(
         OrderDataInterface $orderData,
-        RequestContext $context = null
+        ?RequestContext $context = null
     ): UploadOrderResult {
         $context = $this->requestFactory->prepareUploadContext($context);
         $transaction = $this->uploadTransaction(
@@ -852,7 +852,7 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsResponseException
      * @throws EbicsException
      */
-    public function YCT(OrderDataInterface $orderData, RequestContext $context = null): UploadOrderResult
+    public function YCT(OrderDataInterface $orderData, ?RequestContext $context = null): UploadOrderResult
     {
         $context = $this->requestFactory->prepareUploadContext($context);
         $transaction = $this->uploadTransaction(
@@ -873,7 +873,7 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsResponseException
      * @throws EbicsException
      */
-    public function HVU(RequestContext $context = null): DownloadOrderResult
+    public function HVU(?RequestContext $context = null): DownloadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $transaction = $this->downloadTransaction(
@@ -890,7 +890,7 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsResponseException
      * @throws EbicsException
      */
-    public function HVZ(RequestContext $context = null): DownloadOrderResult
+    public function HVZ(?RequestContext $context = null): DownloadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context);
         $transaction = $this->downloadTransaction(
@@ -906,7 +906,7 @@ final class EbicsClient implements EbicsClientInterface
      * @inheritDoc
      * @throws EbicsException
      */
-    public function HVE(HVEContext $hveContext, RequestContext $context = null): UploadOrderResult
+    public function HVE(HVEContext $hveContext, ?RequestContext $context = null): UploadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context)
             ->setHVEContext($hveContext);
@@ -927,7 +927,7 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsResponseException
      * @throws EbicsException
      */
-    public function HVD(HVDContext $hvdContext, RequestContext $context = null): DownloadOrderResult
+    public function HVD(HVDContext $hvdContext, ?RequestContext $context = null): DownloadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context)
             ->setHVDContext($hvdContext);
@@ -945,7 +945,7 @@ final class EbicsClient implements EbicsClientInterface
      * @throws Exceptions\EbicsResponseException
      * @throws EbicsException
      */
-    public function HVT(HVTContext $hvtContext, RequestContext $context = null): DownloadOrderResult
+    public function HVT(HVTContext $hvtContext, ?RequestContext $context = null): DownloadOrderResult
     {
         $context = $this->requestFactory->prepareStandardContext($context)
             ->setHVTContext($hvtContext);
@@ -1079,7 +1079,7 @@ final class EbicsClient implements EbicsClientInterface
      * @throws EbicsException
      * @throws EbicsResponseException
      */
-    private function downloadTransaction(callable $requestClosure, callable $ackClosure = null): DownloadTransaction
+    private function downloadTransaction(callable $requestClosure, ?callable $ackClosure = null): DownloadTransaction
     {
         $transaction = $this->transactionFactory->createDownloadTransaction();
 
@@ -1320,7 +1320,7 @@ final class EbicsClient implements EbicsClientInterface
      * @return SignatureInterface
      * @throws PasswordEbicsException
      */
-    private function createUserSignature(string $type, array $details = null): SignatureInterface
+    private function createUserSignature(string $type, ?array $details = null): SignatureInterface
     {
         switch ($type) {
             case SignatureInterface::TYPE_A:

--- a/src/Factories/RequestFactory.php
+++ b/src/Factories/RequestFactory.php
@@ -652,7 +652,7 @@ abstract class RequestFactory
         string $transactionKey,
         string $orderData,
         int $segmentNumber,
-        bool $isLastSegment = null
+        ?bool $isLastSegment = null
     ): Request {
         $context = (new RequestContext())
             ->setBank($this->bank)
@@ -694,7 +694,7 @@ abstract class RequestFactory
     public function createTransferDownload(
         string $transactionId,
         int $segmentNumber,
-        bool $isLastSegment = null
+        ?bool $isLastSegment = null
     ): Request {
         $context = (new RequestContext())
             ->setBank($this->bank)
@@ -1011,7 +1011,7 @@ abstract class RequestFactory
         return $request;
     }
 
-    public function prepareStandardContext(RequestContext $requestContext = null): RequestContext
+    public function prepareStandardContext(?RequestContext $requestContext = null): RequestContext
     {
         if (null === $requestContext) {
             $requestContext = new RequestContext();
@@ -1020,7 +1020,7 @@ abstract class RequestFactory
         return $requestContext;
     }
 
-    abstract public function prepareDownloadContext(RequestContext $requestContext = null): RequestContext;
+    abstract public function prepareDownloadContext(?RequestContext $requestContext = null): RequestContext;
 
-    abstract public function prepareUploadContext(RequestContext $requestContext = null): RequestContext;
+    abstract public function prepareUploadContext(?RequestContext $requestContext = null): RequestContext;
 }

--- a/src/Factories/RequestFactoryV2.php
+++ b/src/Factories/RequestFactoryV2.php
@@ -27,7 +27,7 @@ abstract class RequestFactoryV2 extends RequestFactory
         throw new LogicException('Method for EBICS 3.0');
     }
 
-    public function prepareDownloadContext(RequestContext $requestContext = null): RequestContext
+    public function prepareDownloadContext(?RequestContext $requestContext = null): RequestContext
     {
         $requestContext = $this->prepareStandardContext($requestContext);
         if (null === $requestContext->getFdlContext()) {
@@ -39,7 +39,7 @@ abstract class RequestFactoryV2 extends RequestFactory
         return $requestContext;
     }
 
-    public function prepareUploadContext(RequestContext $requestContext = null): RequestContext
+    public function prepareUploadContext(?RequestContext $requestContext = null): RequestContext
     {
         $requestContext = $this->prepareStandardContext($requestContext);
         if (null === $requestContext->getFulContext()) {

--- a/src/Factories/RequestFactoryV30.php
+++ b/src/Factories/RequestFactoryV30.php
@@ -388,7 +388,7 @@ final class RequestFactoryV30 extends RequestFactory
         return $this->createBTU($transaction, $context);
     }
 
-    public function prepareDownloadContext(RequestContext $requestContext = null): RequestContext
+    public function prepareDownloadContext(?RequestContext $requestContext = null): RequestContext
     {
         $requestContext = $this->prepareStandardContext($requestContext);
         if (null === $requestContext->getBTDContext()) {
@@ -400,7 +400,7 @@ final class RequestFactoryV30 extends RequestFactory
         return $requestContext;
     }
 
-    public function prepareUploadContext(RequestContext $requestContext = null): RequestContext
+    public function prepareUploadContext(?RequestContext $requestContext = null): RequestContext
     {
         $requestContext = $this->prepareStandardContext($requestContext);
         if (null === $requestContext->getBTUContext()) {

--- a/src/Factories/SignatureFactory.php
+++ b/src/Factories/SignatureFactory.php
@@ -34,7 +34,7 @@ final class SignatureFactory
      *
      * @return SignatureInterface
      */
-    public function create(string $type, string $publicKey, string $privateKey = null): SignatureInterface
+    public function create(string $type, string $publicKey, ?string $privateKey = null): SignatureInterface
     {
         switch ($type) {
             case SignatureInterface::TYPE_A:
@@ -70,7 +70,7 @@ final class SignatureFactory
      *
      * @return SignatureInterface
      */
-    public function createSignatureE(string $publicKey, string $privateKey = null): SignatureInterface
+    public function createSignatureE(string $publicKey, ?string $privateKey = null): SignatureInterface
     {
         return new Signature(SignatureInterface::TYPE_E, $publicKey, $privateKey);
     }
@@ -81,7 +81,7 @@ final class SignatureFactory
      *
      * @return SignatureInterface
      */
-    public function createSignatureX(string $publicKey, string $privateKey = null): SignatureInterface
+    public function createSignatureX(string $publicKey, ?string $privateKey = null): SignatureInterface
     {
         return new Signature(SignatureInterface::TYPE_X, $publicKey, $privateKey);
     }
@@ -96,7 +96,7 @@ final class SignatureFactory
     public function createSignatureAFromKeys(
         KeyPair $keyPair,
         string $password,
-        X509GeneratorInterface $x509Generator = null
+        ?X509GeneratorInterface $x509Generator = null
     ): SignatureInterface {
         return $this->createSignatureFromKeys($keyPair, $password, SignatureInterface::TYPE_A, $x509Generator);
     }
@@ -111,7 +111,7 @@ final class SignatureFactory
     public function createSignatureEFromKeys(
         KeyPair $keyPair,
         string $password,
-        X509GeneratorInterface $x509Generator = null
+        ?X509GeneratorInterface $x509Generator = null
     ): SignatureInterface {
         return $this->createSignatureFromKeys($keyPair, $password, SignatureInterface::TYPE_E, $x509Generator);
     }
@@ -126,7 +126,7 @@ final class SignatureFactory
     public function createSignatureXFromKeys(
         KeyPair $keyPair,
         string $password,
-        X509GeneratorInterface $x509Generator = null
+        ?X509GeneratorInterface $x509Generator = null
     ): SignatureInterface {
         return $this->createSignatureFromKeys($keyPair, $password, SignatureInterface::TYPE_X, $x509Generator);
     }
@@ -169,7 +169,7 @@ final class SignatureFactory
         KeyPair $keyPair,
         string $password,
         string $type,
-        X509GeneratorInterface $x509Generator = null
+        ?X509GeneratorInterface $x509Generator = null
     ): SignatureInterface {
         $signature = new Signature($type, $keyPair->getPublicKey(), $keyPair->getPrivateKey());
 

--- a/src/Handlers/AuthSignatureHandler.php
+++ b/src/Handlers/AuthSignatureHandler.php
@@ -43,7 +43,7 @@ abstract class AuthSignatureHandler
      *
      * @throws EbicsException
      */
-    public function handle(DOMDocument $request, DOMNode $xmlRequestHeader = null): void
+    public function handle(DOMDocument $request, ?DOMNode $xmlRequestHeader = null): void
     {
         $canonicalizationPath = '//AuthSignature/*';
         $signaturePath = "//*[@authenticate='true']";

--- a/src/Models/Crypt/ASN1.php
+++ b/src/Models/Crypt/ASN1.php
@@ -828,7 +828,7 @@ final class ASN1 implements ASN1Interface
      *
      * @return string|false
      */
-    private function encodeDERInternal($source, array $mapping, string $idx = null, array $special = [])
+    private function encodeDERInternal($source, array $mapping, ?string $idx = null, array $special = [])
     {
         // do not encode (implicitly optional) fields with value set to default
         if (isset($mapping['default']) && $source === $mapping['default']) {

--- a/src/Models/Crypt/X509.php
+++ b/src/Models/Crypt/X509.php
@@ -1043,7 +1043,7 @@ class X509 implements X509Interface
      *
      * @return bool
      */
-    private function removeExtension(string $id, string $path = null): bool
+    private function removeExtension(string $id, ?string $path = null): bool
     {
         $extensions = &$this->extensions($this->currentCert, $path);
 
@@ -1528,7 +1528,7 @@ class X509 implements X509Interface
         }
     }
 
-    final public function setExtension($id, $value, $critical = false, $replace = true, string $path = null): bool
+    final public function setExtension($id, $value, $critical = false, $replace = true, ?string $path = null): bool
     {
         $extensions = &$this->extensions($this->currentCert, $path, true);
 
@@ -1562,7 +1562,7 @@ class X509 implements X509Interface
      *
      * @return array|false
      */
-    private function &extensions(?array &$root, string $path = null, bool $create = false)
+    private function &extensions(?array &$root, ?string $path = null, bool $create = false)
     {
         if (!isset($root)) {
             $root = $this->currentCert;
@@ -1804,7 +1804,7 @@ class X509 implements X509Interface
      *
      * @return mixed
      */
-    private function getExtension(string $id, array $cert = null)
+    private function getExtension(string $id, ?array $cert = null)
     {
         $extensions = $this->extensions($cert);
 
@@ -1876,7 +1876,7 @@ class X509 implements X509Interface
      *
      * @return array|false
      */
-    private function getDNProp(string $propName, array $dn = null, bool $withType = false)
+    private function getDNProp(string $propName, ?array $dn = null, bool $withType = false)
     {
         if (!isset($dn)) {
             $dn = $this->dn;

--- a/src/Models/Keyring.php
+++ b/src/Models/Keyring.php
@@ -64,7 +64,7 @@ final class Keyring
         return $this->version;
     }
 
-    public function setUserSignatureA(SignatureInterface $signature = null): void
+    public function setUserSignatureA(?SignatureInterface $signature = null): void
     {
         $this->userSignatureA = $signature;
     }
@@ -95,7 +95,7 @@ final class Keyring
         return $this->userSignatureAVersion;
     }
 
-    public function setUserSignatureX(SignatureInterface $signature = null): void
+    public function setUserSignatureX(?SignatureInterface $signature = null): void
     {
         $this->userSignatureX = $signature;
     }
@@ -116,7 +116,7 @@ final class Keyring
         return SignatureInterface::X_VERSION2;
     }
 
-    public function setUserSignatureE(SignatureInterface $signature = null): void
+    public function setUserSignatureE(?SignatureInterface $signature = null): void
     {
         $this->userSignatureE = $signature;
     }
@@ -179,7 +179,7 @@ final class Keyring
         return null !== $this->x509Generator;
     }
 
-    public function setBankSignatureX(SignatureInterface $bankSignatureX = null): void
+    public function setBankSignatureX(?SignatureInterface $bankSignatureX = null): void
     {
         $this->bankSignatureX = $bankSignatureX;
     }
@@ -200,7 +200,7 @@ final class Keyring
         return SignatureInterface::X_VERSION2;
     }
 
-    public function setBankSignatureE(SignatureInterface $bankSignatureE = null): void
+    public function setBankSignatureE(?SignatureInterface $bankSignatureE = null): void
     {
         $this->bankSignatureE = $bankSignatureE;
     }

--- a/src/Models/Pdf.php
+++ b/src/Models/Pdf.php
@@ -91,7 +91,7 @@ final class Pdf extends FPDF
      *
      * @return void
      */
-    public function h(string $text, int $size, int $txtColor = null, int $bgColor = null): void
+    public function h(string $text, int $size, ?int $txtColor = null, ?int $bgColor = null): void
     {
         $this->SetY($this->lastY);
         $this->SetFont($this->sansFont, 'B', $size);
@@ -117,7 +117,7 @@ final class Pdf extends FPDF
      *
      * @return void
      */
-    public function c(string $text, string $style = '', bool $shift = true, int $right = null): void
+    public function c(string $text, string $style = '', bool $shift = true, ?int $right = null): void
     {
         $this->SetY($this->lastY);
         if ($right) {
@@ -133,7 +133,7 @@ final class Pdf extends FPDF
         }
     }
 
-    public function pre(string $text, bool $shift = true, int $right = null): void
+    public function pre(string $text, bool $shift = true, ?int $right = null): void
     {
         $this->SetY($this->lastY);
         if ($right) {

--- a/src/Services/FakerHttpClient.php
+++ b/src/Services/FakerHttpClient.php
@@ -96,7 +96,7 @@ final class FakerHttpClient implements HttpClientInterface
      *
      * @return Response
      */
-    private function fixtureOrderType(string $orderType, array $options = null): Response
+    private function fixtureOrderType(string $orderType, ?array $options = null): Response
     {
         switch ($orderType) {
             case 'FUL':

--- a/src/Services/RandomService.php
+++ b/src/Services/RandomService.php
@@ -92,7 +92,7 @@ final class RandomService
      *
      * @return string
      */
-    public function uniqueIdWithDate(string $prefix = null): string
+    public function uniqueIdWithDate(?string $prefix = null): string
     {
         $now = new DateTime();
 

--- a/tests/AbstractEbicsTestCase.php
+++ b/tests/AbstractEbicsTestCase.php
@@ -165,7 +165,7 @@ abstract class AbstractEbicsTestCase extends TestCase
         self::assertEquals('011000', $code, $reportText);
     }
 
-    protected function assertExceptionCode(string $code = null)
+    protected function assertExceptionCode(?string $code = null)
     {
         if (null !== $code) {
             $code = (int)$code;


### PR DESCRIPTION
PHP 8.4 throws deprecation notices if parameters or properties have a `null` default value, but the type is not defined as nullable. https://wiki.php.net/rfc/deprecate-implicitly-nullable-types

This PR should update all such cases by for example changing `array $details = null` to `?array $details = null`.

The linked RFC says ...

>  As the `?T` syntax has existed since PHP 7.1, which is 7 years old, the various tools available to fix this issue automatically, and this issue being easily resolved as it requires a single change at the declaration site (instead of potentially infinite call-site changes), we deem this deprecation to be easily handled and fixed.

... I think this should work fine with your current support of PHP 7.4.