### PR TITLE
EBICS 3.0 CH compatibility

### DIFF
--- a/src/Builders/Request/OrderDetailsBuilderV3.php
+++ b/src/Builders/Request/OrderDetailsBuilderV3.php
@@ -192,6 +192,16 @@ final class OrderDetailsBuilderV3 extends OrderDetailsBuilder
             );
         }
 
+        if(true === $btuContext->getSignatureFlag()) {
+            $xmlSignatureFlag = $this->dom->createElement('SignatureFlag');
+
+            if(true === $btuContext->getSignatureFlagEds()) {
+                $xmlSignatureFlag->setAttribute('requestEDS', 'true');
+            }
+
+            $xmlBTUOrderParams->appendChild($xmlSignatureFlag);
+        }
+
         return $this;
     }
 

--- a/src/Builders/Request/OrderDetailsBuilderV3.php
+++ b/src/Builders/Request/OrderDetailsBuilderV3.php
@@ -192,10 +192,10 @@ final class OrderDetailsBuilderV3 extends OrderDetailsBuilder
             );
         }
 
-        if(true === $btuContext->getSignatureFlag()) {
+        if (true === $btuContext->getSignatureFlag()) {
             $xmlSignatureFlag = $this->dom->createElement('SignatureFlag');
 
-            if(true === $btuContext->getSignatureFlagEds()) {
+            if (true === $btuContext->getSignatureFlagEds()) {
                 $xmlSignatureFlag->setAttribute('requestEDS', 'true');
             }
 

--- a/src/Contexts/BTFContext.php
+++ b/src/Contexts/BTFContext.php
@@ -14,6 +14,8 @@ abstract class BTFContext extends ServiceContext
     private ?string $msgNameVariant = null;
     private ?string $msgNameVersion = null;
     private ?string $msgNameFormat = null;
+    private bool $signatureFlag = false;
+    private bool $signatureFlagEds = false;
 
     public function setContainerFlag(string $containerFlag): self
     {
@@ -61,5 +63,29 @@ abstract class BTFContext extends ServiceContext
     public function getMsgNameFormat(): ?string
     {
         return $this->msgNameFormat;
+    }
+
+    public function setSignatureFlag(bool $signatureFlag): self
+    {
+        $this->signatureFlag = $signatureFlag;
+
+        return $this;
+    }
+
+    public function getSignatureFlag(): bool
+    {
+        return $this->signatureFlag;
+    }
+
+    public function setSignatureFlagEds(bool $signatureFlagEds): self
+    {
+        $this->signatureFlagEds = $signatureFlagEds;
+
+        return $this;
+    }
+
+    public function getSignatureFlagEds(): bool
+    {
+        return $this->signatureFlagEds;
     }
 }

--- a/src/Factories/RequestFactoryV30.php
+++ b/src/Factories/RequestFactoryV30.php
@@ -269,7 +269,13 @@ final class RequestFactoryV30 extends RequestFactory
         $btdContext->setServiceName('REP');
         $btdContext->setMsgName('camt.054');
         $btdContext->setContainerType('ZIP');
-        $btdContext->setServiceOption('XQRR');
+
+        /**
+         * EBICS 3.0 does not support Service Option "XQRR" in camt.054 version 04.
+         */
+        if($btdContext->getMsgNameVersion() !== "04") {
+            $btdContext->setServiceOption('XQRR');
+        }
 
         return $this->createBTD($context);
     }

--- a/src/Factories/RequestFactoryV30.php
+++ b/src/Factories/RequestFactoryV30.php
@@ -273,7 +273,7 @@ final class RequestFactoryV30 extends RequestFactory
         /**
          * EBICS 3.0 does not support Service Option "XQRR" in camt.054 version 04.
          */
-        if($btdContext->getMsgNameVersion() !== "04") {
+        if ($btdContext->getMsgNameVersion() !== "04") {
             $btdContext->setServiceOption('XQRR');
         }
 


### PR DESCRIPTION
- (fix) According to [SIX Group EBICS 3.0 BTF-Codes CH](https://www.six-group.com/dam/download/banking-services/standardization/ebics/ebics3.0-btf-en.pdf), the `XQRR` service option is not available in EBICS 3.0 v4 for camt.054. 
- (feature) Add support for the `SignatureFlag` according to [SIX Group EBICS 3.0 Standardization](https://www.six-group.com/dam/download/banking-services/interbank-clearing/en/standardization/ebics/ebics_3_0.pdf)