### PR TITLE
Fix: Wrong parameter order when invoking signature factory

### DIFF
--- a/src/Handlers/OrderDataHandlerV2.php
+++ b/src/Handlers/OrderDataHandlerV2.php
@@ -120,8 +120,8 @@ abstract class OrderDataHandlerV2 extends OrderDataHandler
             $publicKey = $x509->getPublicKey();
 
             $signature = $this->signatureFactory->createSignatureXFromDetails(
-                $publicKey->getModulus(),
-                $publicKey->getExponent()
+                $publicKey->getExponent(),
+                $publicKey->getModulus()
             );
 
             $signature->setCertificateContent($certificateContent);
@@ -134,8 +134,8 @@ abstract class OrderDataHandlerV2 extends OrderDataHandler
             $exponentValueDe = base64_decode($exponentValue);
 
             $signature = $this->signatureFactory->createSignatureXFromDetails(
-                $this->bigIntegerFactory->create($modulusValueDe, 256),
-                $this->bigIntegerFactory->create($exponentValueDe, 256)
+                $this->bigIntegerFactory->create($exponentValueDe, 256),
+                $this->bigIntegerFactory->create($modulusValueDe, 256)
             );
         }
 
@@ -163,8 +163,8 @@ abstract class OrderDataHandlerV2 extends OrderDataHandler
             $publicKey = $x509->getPublicKey();
 
             $signature = $this->signatureFactory->createSignatureEFromDetails(
-                $publicKey->getModulus(),
-                $publicKey->getExponent()
+                $publicKey->getExponent(),
+                $publicKey->getModulus()
             );
 
             $signature->setCertificateContent($certificateContent);
@@ -177,8 +177,8 @@ abstract class OrderDataHandlerV2 extends OrderDataHandler
             $exponentValueDe = base64_decode($exponentValue);
 
             $signature = $this->signatureFactory->createSignatureEFromDetails(
-                $this->bigIntegerFactory->create($modulusValueDe, 256),
-                $this->bigIntegerFactory->create($exponentValueDe, 256)
+                $this->bigIntegerFactory->create($exponentValueDe, 256),
+                $this->bigIntegerFactory->create($modulusValueDe, 256)
             );
         }
 

--- a/src/Handlers/OrderDataHandlerV30.php
+++ b/src/Handlers/OrderDataHandlerV30.php
@@ -84,8 +84,8 @@ final class OrderDataHandlerV30 extends OrderDataHandler
         $publicKey = $x509->getPublicKey();
 
         $signature = $this->signatureFactory->createSignatureXFromDetails(
-            $publicKey->getModulus(),
-            $publicKey->getExponent()
+            $publicKey->getExponent(),
+            $publicKey->getModulus()
         );
 
         $signature->setCertificateContent($certificateContent);
@@ -117,8 +117,8 @@ final class OrderDataHandlerV30 extends OrderDataHandler
         $publicKey = $x509->getPublicKey();
 
         $signature = $this->signatureFactory->createSignatureEFromDetails(
-            $publicKey->getModulus(),
-            $publicKey->getExponent()
+            $publicKey->getExponent(),
+            $publicKey->getModulus()
         );
 
         $signature->setCertificateContent($certificateContent);


### PR DESCRIPTION
I'm developing a PHP application with your library: I'm using EBICS 2.5. After calling HPB(), I've noticed that the library creates strange keys. The RSA public keys details 'exponent' and 'modulus' are mixed up. 

I've found the issue: The signature factory is invoked with wrong parameter order. This merge request fixes the factory call.

Please feel free to comment.