### PR TITLE
Add postponed code to ignore in translation download receipt return code

### DIFF
--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -343,6 +343,11 @@ final class EbicsClient implements EbicsClientInterface
             return;
         }
 
+        // For Download Postprocess Skipped (postponed).
+        if ('011001' === $errorCode) {
+            return;
+        }
+
         $reportText = $this->responseHandler->retrieveH00XReportText($response);
         EbicsExceptionFactory::buildExceptionFromCode($errorCode, $reportText, $request, $response);
     }

--- a/src/Handlers/ResponseHandler.php
+++ b/src/Handlers/ResponseHandler.php
@@ -261,6 +261,11 @@ abstract class ResponseHandler
                 return;
             }
 
+            // For Download Postprocess Skipped (postponed).
+            if ('011001' === $errorCode) {
+                return;
+            }
+
             $reportText = $this->retrieveH00XReportText($response);
             EbicsExceptionFactory::buildExceptionFromCode($errorCode, $reportText, $request, $response);
         }


### PR DESCRIPTION
Added support for EBICS return code '011001' (Download Postprocess Skipped) to be ignored when checking translation download receipt return codes, similar to how '011000' (Transaction Done) is already handled.

Changes made to:
- EbicsClient::checkH00XReturnCode()
- ResponseHandler::checkResponseReturnCode()