### PR TITLE
Fix Warning: openssl_x509_fingerprint(): X.509 Certificate cannot be retrieved

### DIFF
--- a/src/Services/CryptService.php
+++ b/src/Services/CryptService.php
@@ -338,12 +338,30 @@ final class CryptService implements CryptServiceInterface
         string $algorithm = 'sha256',
         bool $rawOutput = true
     ): string {
-        $fingerprint = openssl_x509_fingerprint($certContent, $algorithm, $rawOutput);
+        $normalizedCert = $this->normalizeCertificatePem($certContent);
+        $fingerprint = openssl_x509_fingerprint($normalizedCert, $algorithm, $rawOutput);
         if (false === $fingerprint) {
             throw new RuntimeException('Can not calculate fingerprint for certificate.');
         }
 
         return $fingerprint;
+    }
+    /**
+     * Helper to normalize PEM formatting before fingerprinting.
+     * @param string $certContent
+     * @return string
+     */
+    private function normalizeCertificatePem(string $certContent): string
+    {
+        $certContent = trim($certContent);
+        $certContent = str_replace("\r\n", "\n", $certContent);
+        $certContent = str_replace("\r", "\n", $certContent);
+
+        $lines = explode("\n", $certContent);
+        $lines = array_filter($lines, fn (string $line): bool => trim($line) !== '');
+        $certContent = implode("\n", $lines) . "\n";
+
+        return $certContent;
     }
 
     public function generateNonce(): string

--- a/tests/Services/CryptServiceTest.php
+++ b/tests/Services/CryptServiceTest.php
@@ -14,6 +14,9 @@ use EbicsApi\Ebics\Services\CryptService;
 use EbicsApi\Ebics\Services\RandomService;
 use EbicsApi\Ebics\Tests\AbstractEbicsTestCase;
 use LogicException;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
@@ -519,7 +522,7 @@ class CryptServiceTest extends AbstractEbicsTestCase
     {
         $keyring = new Keyring(Keyring::VERSION_25);
         $keyring->setPassword('testpassword');
-        
+
         $orderDataEncrypted = new Buffer(tempnam(sys_get_temp_dir(), 'ebics_test_'));
         $orderDataCompressed = new Buffer(tempnam(sys_get_temp_dir(), 'ebics_test_'));
 
@@ -532,5 +535,96 @@ class CryptServiceTest extends AbstractEbicsTestCase
             $orderDataCompressed,
             'encrypted_transaction_key'
         );
+    }
+
+    /**
+     * Generate a self-signed test certificate in PEM format.
+     */
+    private function generateTestCertificate(): ?string
+    {
+        $dn = [
+            "countryName" => "US",
+            "stateOrProvinceName" => "Test",
+            "localityName" => "Test",
+            "organizationName" => "Test",
+            "commonName" => "test.example.com"
+        ];
+
+        $privkey = openssl_pkey_new();
+        if ($privkey === false) {
+            return null;
+        }
+
+        $csr = openssl_csr_new($dn, $privkey);
+        if ($csr === false) {
+            return null;
+        }
+
+        $cert = openssl_csr_sign($csr, null, $privkey, 365);
+        if ($cert === false) {
+            return null;
+        }
+
+        openssl_x509_export($cert, $certContent);
+
+        return $certContent;
+    }
+
+    /**
+     * Provide various PEM transformation functions to test normalization.
+     */
+    public static function malformedCertificateFormatsProvider(): array
+    {
+        return [
+            'crlf_line_endings' => [
+                static fn (string $pem): string => str_replace("\n", "\r\n", $pem),
+            ],
+            'cr_line_endings' => [
+                static fn (string $pem): string => str_replace("\n", "\r", $pem),
+            ],
+            'empty_lines_between' => [
+                static fn (string $pem): string => str_replace("\n", "\n\n", $pem),
+            ],
+            'leading_trailing_whitespace' => [
+                static fn (string $pem): string => "   \n  " . $pem . "  \n   ",
+            ],
+        ];
+    }
+
+    /**
+     * Test that calculateCertificateFingerprint normalizes PEM before fingerprinting.
+     */
+    #[DataProvider('malformedCertificateFormatsProvider')]
+    #[Group('crypt-services')]
+    #[CoversNothing]
+    public function testCalculateCertificateFingerprintNormalizesPem(callable $transform): void
+    {
+        $certContent = $this->generateTestCertificate();
+
+        if ($certContent === null) {
+            self::markTestSkipped('Cannot generate test certificate');
+        }
+
+        $malformedCert = $transform($certContent);
+
+        self::assertNotEquals(
+            $certContent,
+            $malformedCert,
+            'The transformation should produce a malformed certificate'
+        );
+
+        $expectedFingerprint = $this->cryptService->calculateCertificateFingerprint(
+            $certContent,
+            'sha256',
+            false
+        );
+
+        $actualFingerprint = $this->cryptService->calculateCertificateFingerprint(
+            $malformedCert,
+            'sha256',
+            false
+        );
+
+        self::assertEquals($expectedFingerprint, $actualFingerprint);
     }
 }


### PR DESCRIPTION
Hello @andrew-svirin ,

We recently encountered an issue with a French bank, [_Pouyanne_](https://www.pouyanne.fr/), which, for some strange reason, sends us data in different formats. It is an independent bank, and we have quite a few difficulties communicating with them via EBICS. I will open another pull request for a separate issue we have encountered with them.

In this specific case, we receive certificates in a non-compliant PEM format, notably with line breaks using` /r/n `instead of `/n`, which triggers the following error: "Warning: openssl_x509_fingerprint(): X.509 Certificate cannot be retrieved".

I took the liberty of adding a method to normalize all of this in [src/Services/CryptService.php](https://github.com/ebics-api/ebics-client-php/blob/3.x/src/Services/CryptService.php#L336) along with tests. I will let you review it and share your thoughts on the situation.

Cheers