### PR TITLE
fix(ebicsClient): decode base64 in oneshot to avoid Length incorrect …

### DIFF
--- a/src/EbicsClient.php
+++ b/src/EbicsClient.php
@@ -748,11 +748,11 @@ final class EbicsClient implements EbicsClientInterface
         $orderDataEncoded->rewind();
 
         $orderDataDecoded = $this->bufferFactory->create();
-        while (!$orderDataEncoded->eof()) {
-            $orderDataDecoded->write(base64_decode($orderDataEncoded->read()));
-        }
-        $orderDataDecoded->rewind();
+
+        $base64Content = $orderDataEncoded->readContent();
+        $orderDataDecoded->write(base64_decode($base64Content));
         unset($orderDataEncoded);
+        $orderDataDecoded->rewind();
 
         $orderDataCompressed = $this->bufferFactory->create();
         $this->cryptService->decryptOrderDataCompressed(


### PR DESCRIPTION
Hi @andrew-svirin, I found a second issue with Pouyanne Bank.

I’m not sure this is the proper fix. I just changed it this way, and it seems to work for now. I basically used AI to test a lot of different approaches and ended up finding this solution.

### Problem

When downloading order data via EBICS 3.0, `AES::unpad()` threw `Length incorrect` on certain payloads. The root cause was a **base64 chunking bug** in `CryptService::decryptOrderDataCompressed()`.

The original code decoded base64 in a `while (!eof())` loop, reading 1024-byte chunks:

```php
while (!$orderDataEncoded->eof()) {
    $orderDataDecoded->write(base64_decode($orderDataEncoded->read()));
}
```
`Buffer::read()` reads 1024 bytes at a time by default. Base64 requires 4-character blocks (4 chars → 3 bytes). When the total base64 length is not a multiple of 1024, the last chunk is partial. Worse, if a chunk boundary cuts through the trailing = padding, `base64_decode()` silently produces corrupted binary, losing bytes at every chunk boundary.

Since the decoded payload is AES-encrypted ciphertext, missing even a single byte makes the final block 15 bytes instead of 16. `AES::unpad()` then reads the last byte as the padding length, gets a garbage value, and throws Length incorrect.

### Solution

Read the entire base64 content as a single string before decoding:
```php
$base64Content = $orderDataEncoded->readContent();
$orderDataDecoded->write(base64_decode($base64Content));
unset($orderDataEncoded);
```

This guarantees base64_decode() receives the full payload including the = padding, producing the exact original binary without truncation.
